### PR TITLE
#6 署名配置ステップの微調整

### DIFF
--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -32,6 +32,9 @@ jobs:
           fileName: 'release.jks'
           encodedString: ${{ secrets.KEYSTORE }}
 
+      - name: list up *.jks
+        run: echo "${ls *.jks}"
+
       - name: Build release apk
         run: ./gradlew app:assembleRelease
         env:

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -26,6 +26,7 @@ jobs:
 
       # https://github.com/timheuer/base64-to-file
       - name: Set keystore's file
+        id: set_keystore
         uses: timheuer/base64-to-file@v1.2
         with:
           fileName: 'release.jks'


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#8 で下記のエラーが出たので、試しに微調整を追加。
軽微な変更のため、詳細は割愛します。

> 2023-10-27T13:45:23.7247835Z ##[group]Run ./gradlew app:assembleRelease
> 2023-10-27T13:45:23.7248834Z [36;1m./gradlew app:assembleRelease[0m
> 2023-10-27T13:45:23.7277366Z shell: /usr/bin/bash -e {0}
> 2023-10-27T13:45:23.7278092Z env:
> 2023-10-27T13:45:23.7278887Z   JAVA_HOME: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T13:45:23.7280170Z   JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T13:45:23.7281353Z   KEYSTORE_PASSWORD: ***
> 2023-10-27T13:45:23.7282070Z   KEY_ALIAS: ***
> 2023-10-27T13:45:23.7282759Z   KEY_PASSWORD: ***
> 2023-10-27T13:45:23.7283409Z ##[endgroup]
> 2023-10-27T13:45:23.8394073Z Downloading https://services.gradle.org/distributions/gradle-8.0-bin.zip
> 2023-10-27T13:45:25.6892080Z  ...........10%............20%............30%............40%............50%............60%...........70%............80%............90%............100%
> 2023-10-27T13:45:27.6822793Z 
> 2023-10-27T13:45:27.6823693Z Welcome to Gradle 8.0!
> 2023-10-27T13:45:27.6824524Z 
> 2023-10-27T13:45:27.6837321Z For more details see https://docs.gradle.org/8.0/release-notes.html
> 2023-10-27T13:45:27.6838773Z 
> 2023-10-27T13:45:27.7818298Z Starting a Gradle Daemon (subsequent builds will be faster)
> 2023-10-27T13:45:59.6862416Z 
> 2023-10-27T13:45:59.6862456Z 
> 2023-10-27T13:45:59.6864246Z FAILURE: Build failed with an exception.
> 2023-10-27T13:45:59.6865665Z Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
> 2023-10-27T13:45:59.6867598Z 
> 2023-10-27T13:45:59.6867607Z 
> 2023-10-27T13:45:59.6868634Z * Where:
> 2023-10-27T13:45:59.6870455Z You can use '--warning-mode all' to show the individual deprecation warnings and determine 
 if they come from your own scripts or plugins.
> 2023-10-27T13:45:59.6873839Z Build file '/home/runner/work/yumemi-inc_android-engineer-codecheck/yumemi-inc_android-engineer-codecheck/app/build.gradle' line: 50
> 2023-10-27T13:45:59.6875220Z 
> 2023-10-27T13:45:59.6875931Z 
> 2023-10-27T13:45:59.6974921Z See https://docs.gradle.org/8.0/userguide/command_line_interface.html#sec:command_line_warnings
> 2023-10-27T13:45:59.6977240Z * What went wrong:
> 2023-10-27T13:45:59.6978827Z A problem occurred evaluating project ':app'.
> 2023-10-27T13:45:59.6981286Z > Could not get unknown property 'release' for SigningConfig container of type org.gradle.api.internal.FactoryNamedDomainObjectContainer.
> 2023-10-27T13:45:59.6982870Z 
> 2023-10-27T13:45:59.6983479Z * Try:
> 2023-10-27T13:45:59.6984494Z > Run with --stacktrace option to get the stack trace.
> 2023-10-27T13:45:59.6986046Z > Run with --info or --debug option to get more log output.
> 2023-10-27T13:45:59.6987328Z > Run with --scan to get full insights.
> 2023-10-27T13:45:59.6988246Z 
> 2023-10-27T13:45:59.6988812Z * Get more help at https://help.gradle.org
> 2023-10-27T13:45:59.6989753Z 
> 2023-10-27T13:45:59.6990202Z BUILD FAILED in 35s
> 2023-10-27T13:46:00.1645891Z ##[error]Process completed with exit code 1.

https://github.com/tshion/yumemi-inc_android-engineer-codecheck/actions/runs/6668047993