### PR TITLE
#6 署名ファイルの出力先パスの調整

### DIFF
--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -30,6 +30,7 @@ jobs:
         uses: timheuer/base64-to-file@v1.2
         with:
           fileName: 'release.jks'
+          fileDir: './'
           encodedString: ${{ secrets.KEYSTORE }}
 
       - name: list up *.jks


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#11 で下記のように署名出力が出来ていないので、試しに微調整を追加。
軽微な変更のため、詳細は割愛します。

> 2023-10-27T14:20:30.9562049Z ##[group]Run echo $(ls *.jks)
> 2023-10-27T14:20:30.9562959Z [36;1mecho $(ls *.jks)[0m
> 2023-10-27T14:20:30.9595325Z shell: /usr/bin/bash -e {0}
> 2023-10-27T14:20:30.9597259Z env:
> 2023-10-27T14:20:30.9598199Z   JAVA_HOME: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T14:20:30.9599720Z   JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T14:20:30.9600974Z ##[endgroup]
> 2023-10-27T14:20:30.9688908Z ls: cannot access '*.jks': No such file or directory

https://github.com/tshion/yumemi-inc_android-engineer-codecheck/actions/runs/6668449076/job/18124034933