### PR TITLE
#6 スクリプト部分のブラッシュアップ

### DIFF
--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -58,6 +58,6 @@ jobs:
           git push origin "$(cat TAG_NAME)"
 
       - name: Create release with assets
-        run: gh release create "${{ steps.app-version.outputs.version-name }}" 'app/build/outputs/apk/release/app-release.apk'
+        run: gh release create "${{ steps.app-version.outputs.version-name }}" 'app/build/outputs/apk/release/app-release.apk' 'app/build/outputs/mapping/release/mapping.txt'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -46,15 +46,16 @@ jobs:
       - name: Pick version name
         id: app-version
         run: |
-          echo $(./gradlew app:pickVersionName) > VERSION_NAME
-          echo $(VERSION_NAME)
-          echo "version-name=$(cat VERSION_NAME)" >> "$GITHUB_OUTPUT"
+          echo "$(./gradlew app:showVersionName)" > TMP_LOG
+          echo "$(head -n 1 TMP_LOG)" > TMP_LOG
+          echo "app version: $(cat TMP_LOG)"
+          echo "version-name=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
 
       - name: Set git tag
         run: |
           echo "${{ steps.app-version.outputs.version-name }}" > TAG_NAME
-          git tag $(cat TAG_NAME)
-          git push origin $(cat TAG_NAME)
+          git tag "$(cat TAG_NAME)"
+          git push origin "$(cat TAG_NAME)"
 
       - name: Create release with assets
         run: gh release create "${{ steps.app-version.outputs.version-name }}" 'app/build/outputs/apk/release/app-release.apk'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,8 +88,8 @@ dependencies {
 }
 
 
-// アプリバージョン名の抜き出し
-tasks.register('pickVersionName') {
+// アプリバージョン名の表示
+tasks.register('showVersionName') {
     def file = rootProject.file('./app/build/outputs/apk/release/output-metadata.json')
     def versionName = 'unknown'
     if (file.exists()) {
@@ -97,6 +97,5 @@ tasks.register('pickVersionName') {
         def matches = (text =~ /"versionName": "(.+)",/)
         versionName = matches[0][1]
     }
-    println("version: ${versionName}")
-    return versionName
+    println(versionName)
 }


### PR DESCRIPTION
* [x] 既存改良
* [x] 不具合修正

## 概要
#12 で下記のエラーが出たので、試しに微調整を追加。

さらに、GitHub Releases のAssets にmapping.txt を含めるようにしました。

軽微な変更のため、詳細は割愛します。


> 2023-10-27T14:58:14.5628905Z ##[group]Run echo "version: 1.0.0 > Task :app:pickVersionName UP-TO-DATE Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0. You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins. See https://docs.gradle.org/8.0/userguide/command_line_interface.html#sec:command_line_warnings BUILD SUCCESSFUL in 1s" > TAG_NAME
> 2023-10-27T14:58:14.5634843Z [36;1mecho "version: 1.0.0 > Task :app:pickVersionName UP-TO-DATE Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0. You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins. See https://docs.gradle.org/8.0/userguide/command_line_interface.html#sec:command_line_warnings BUILD SUCCESSFUL in 1s" > TAG_NAME[0m
> 2023-10-27T14:58:14.5638043Z [36;1mgit tag $(cat TAG_NAME)[0m
> 2023-10-27T14:58:14.5638662Z [36;1mgit push origin $(cat TAG_NAME)[0m
> 2023-10-27T14:58:14.5670596Z shell: /usr/bin/bash -e {0}
> 2023-10-27T14:58:14.5671067Z env:
> 2023-10-27T14:58:14.5672424Z   JAVA_HOME: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T14:58:14.5673416Z   JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Microsoft_jdk/17.0.7/x64
> 2023-10-27T14:58:14.5674172Z ##[endgroup]
> 2023-10-27T14:58:14.5938992Z fatal: too many arguments
> 2023-10-27T14:58:14.5960826Z ##[error]Process completed with exit code 128.

https://github.com/tshion/yumemi-inc_android-engineer-codecheck/actions/runs/6668814167