### PR TITLE
#6 リポジトリ書き込み許可の追記

### DIFF
--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#13 で下記のエラーが出たので、試しに微調整を追加。
軽微な変更のため、詳細は割愛します。

> 2023-10-27T23:27:53.5332443Z remote: Permission to tshion/yumemi-inc_android-engineer-codecheck.git denied to github-actions[bot].
> 2023-10-27T23:27:53.5336956Z fatal: unable to access 'https://github.com/tshion/yumemi-inc_android-engineer-codecheck/': The requested URL returned error: 403

https://github.com/tshion/yumemi-inc_android-engineer-codecheck/actions/runs/6673185609

