### PR TITLE
#19 アプリ1.0.0 が起動しない不具合の修正

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,2 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# https://developer.android.com/guide/navigation/use-graph/pass-data#proguard_considerations
+-keepnames class * extends android.os.Parcelable


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#19 で報告されているクラッシュへの対応を行いました。

原因は、release ビルドをすると画面遷移時のパラメータが必要以上に最適化され、アプリで取り扱うことが出来ずクラッシュしていました。



## 変更点
### 修正
* ProGuard ルールの見直し



## 確認事項
* [ ] 下記の手順を踏んで、アプリが正常に起動する
    1. release ビルドを実行する
    1. 生成されたapk をAndroid 端末にインストールする
    1. アプリを起動する



## 備考
### 参考文献
* [Pass data between destinations  |  Android Developers](https://developer.android.com/guide/navigation/use-graph/pass-data?hl=en#proguard_considerations)
