### PR TITLE
#23 Gradle Build Cache の有効化

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Gradle Build Cache
+org.gradle.caching=true


### PR DESCRIPTION
* [x] 既存改良

## 概要
Gradle Build Cache を有効化し、主に"Rebuild Project" の実行時間を短縮しました。

### 参考記録
マシン情報 | 未設定 | キャッシュ利用時
--- | :---: | :---:
HP ENVY TE01<br />(Windows 11 Pro 22H2, Intel Core i7-9700, 32GB) | 7s | 3s
MacBook Pro 2019<br />(Ventura 13.5.2, Intel Core i5, 16GB) | 6s | 1s



## 変更点
### 追加
* `org.gradle.caching=true` の設定追加



## 確認事項
ビルドキャッシュを利用した場合、`??? from cache` というログが出るので、その有無で動作確認をお願いしたいです。

* [ ] 下記の手順を試し、Gradle ビルドキャッシュが利用されていることを確認する
    1. 本PR をクローンする
    1. Android Studio を開き、"Rebuild Project" を試す
    1. (キャッシュがある場合) Android Studio のBuild タブを確認すると下記のようなログがある
        ``` log
        BUILD SUCCESSFUL in 3s
        38 actionable tasks: 13 executed, 25 from cache
        ```



## 備考
* 1.0.3 時点の実装は、ファイル数も少ないため、あまり効果を感じにくいかもしれません
