### PR TITLE
#28 StrictMode 設定の整備

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:name=".DebugApplication"
+        tools:replace="android:name" />
+</manifest>

--- a/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.android.code_check
+
+/**
+ * Debug ビルド時に適用するApplication クラス
+ */
+class DebugApplication : MainApplication()

--- a/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
@@ -20,7 +20,7 @@ class DebugApplication : MainApplication() {
         StrictMode.VmPolicy.Builder()
             .detectAll()
             .penaltyLog()
-            .penaltyDeath()
+            // .penaltyDeath() // FIXME: 1.0.3 時点では通信実行時に引っ掛かるので、一時的に封印
             .build()
             .also { StrictMode.setVmPolicy(it) }
         // endregion

--- a/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
@@ -1,6 +1,7 @@
 package jp.co.yumemi.android.code_check
 
 import android.os.StrictMode
+import androidx.fragment.app.strictmode.FragmentStrictMode
 
 /**
  * Debug ビルド時に適用するApplication クラス
@@ -25,5 +26,18 @@ class DebugApplication : MainApplication() {
         // endregion
 
         super.onCreate()
+
+        // region: FragmentStrictMode の設定
+        FragmentStrictMode.Policy.Builder()
+            .detectFragmentReuse()
+            .detectFragmentTagUsage()
+            .detectRetainInstanceUsage()
+            .detectSetUserVisibleHint()
+            .detectTargetFragmentUsage()
+            .detectWrongFragmentContainer()
+            .penaltyDeath()
+            .build()
+            .also { FragmentStrictMode.defaultPolicy = it }
+        // endregion
     }
 }

--- a/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
@@ -1,6 +1,29 @@
 package jp.co.yumemi.android.code_check
 
+import android.os.StrictMode
+
 /**
  * Debug ビルド時に適用するApplication クラス
  */
-class DebugApplication : MainApplication()
+class DebugApplication : MainApplication() {
+
+    override fun onCreate() {
+        // region: StrictMode の設定
+        StrictMode.ThreadPolicy.Builder()
+            .detectAll()
+            .penaltyLog()
+            .penaltyFlashScreen()
+            .build()
+            .also { StrictMode.setThreadPolicy(it) }
+
+        StrictMode.VmPolicy.Builder()
+            .detectAll()
+            .penaltyLog()
+            .penaltyDeath()
+            .build()
+            .also { StrictMode.setVmPolicy(it) }
+        // endregion
+
+        super.onCreate()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    
+
     <application
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
@@ -1,0 +1,5 @@
+package jp.co.yumemi.android.code_check
+
+import android.app.Application
+
+open class MainApplication : Application()


### PR DESCRIPTION
* [x] 既存改良

## 概要
#28 の内容に従って、StrictMode 設定を整備しました。

ただし、1.0.2 時点で通信実行するとVmPolicy に引っ掛かることが分かったので、
`penaltyDeath()` をひとまずコメントアウトしています。

今後の改修で違反事項に対応していきたいと思います。



## 変更点
### 追加
* カスタムApplication クラスの追加
    * MainApplication: どのビルドでも共通
    * DebugApplication: Debug ビルドのみ有効
* StrictMode の設定追加

### 修正
* AndroidManifest にカスタムApplication クラスの設定追加



## 確認事項
* [ ] debug ビルドで、アプリで検索を行うと、StrictMode の警告ログが出力される
* [ ] release ビルドで、上記の手順を行っても、特に何も出ない



## 備考
* 特になし
