### PR TITLE
#37 空欄で検索した際にエラーメッセージを表示するように修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -40,8 +40,16 @@ class OneFragment: Fragment(R.layout.fragment_one){
                 if (action== EditorInfo.IME_ACTION_SEARCH){
                     editText.text.toString().also {
                         try {
-                            _viewModel.searchResults(it).apply{
-                                _adapter.submitList(this)
+                            if (it.isNotBlank()) {
+                                _viewModel.searchResults(it).apply {
+                                    _adapter.submitList(this)
+                                }
+                            } else {
+                                Toast.makeText(
+                                    requireContext(),
+                                    getString(R.string.validation_blank),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                             }
                         } catch (e: UnknownHostException) {
                             Toast.makeText(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
     <string name="app_name">Android Engineer CodeCheck</string>
     <string name="error_offline">通信状態が悪いようです。しばらく時間を置いてから再度お試しください。</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
+    <string name="validation_blank">何か入力してください。</string>
     <string name="written_language">Written in %s</string>
 </resources>

--- a/variables.gradle
+++ b/variables.gradle
@@ -2,7 +2,7 @@ ext {
     // アプリバージョン
     def appVersionMajor = 1
     def appVersionMinor = 0
-    def appVersionPatch = 2
+    def appVersionPatch = 3
     appVersionCode = 10000 * appVersionMajor + 100 * appVersionMinor + appVersionPatch
     appVersionName = "${appVersionMajor}.${appVersionMinor}.${appVersionPatch}"
 }


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#37 で報告のあった事象の修正。



## 変更点
### 修正
* 空欄で検索した際に、エラーメッセージを表示するように修正
* バージョン更新



## 確認事項
* [ ]  下記の手順を踏んだ時に、アプリがクラッシュしない
    1. アプリを起動する
    1. 入力欄をタップする
    1. 何も入力しないまま検索する
    1. 空欄による検証エラーメッセージがトースト表示される
* [ ] アプリのバージョンを確認すると`1.0.3` である



## 備考
* 特になし
