### PR TITLE
#40 debug ビルドを識別する設定を追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = '.debug'
+            versionNameSuffix = '.debug'
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">[D]Android Engineer CodeCheck</string>
+</resources>


### PR DESCRIPTION
* [x] 既存改良

## 概要
debug ビルドだと一目でわかるように、下記の設定を加えました。

> * application id の末尾に .debug がついている
> * アプリ名の先頭に [D] という表記がついている
> * アプリバージョンの末尾に.debug がついている



## 変更点
### 追加
* debug ビルドのみに適用されるアプリ名のリソース定義を追加

## 修正
* アプリのID とバージョン名の末尾に識別子を付けるように修正



## 確認事項
すべてdebug ビルドでお試しくださいませ。

* [ ] 本PR をビルドしたものと、1.0.x でリリースされているものが共存できる
* [ ] アプリ名の先頭に `[D]` という表記がついている
* [ ] アプリバージョンの末尾に `.debug` がついている



## 備考
* 特になし
