### PR TITLE
#18 ログ関連の設定ブラッシュアップ

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,9 @@ dependencies {
 
     // LeakCanary
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
+
+    // Timber
+    implementation "com.jakewharton.timber:timber:${libver.timber}"
 }
 
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,2 +1,10 @@
 # https://developer.android.com/guide/navigation/use-graph/pass-data#proguard_considerations
 -keepnames class * extends android.os.Parcelable
+
+# Log
+# https://www.jssec.org/dl/android_securecoding_20220829/4_using_technology_in_a_safe_way.html#system-out-err
+-assumenosideeffects class android.util.Log {
+    public static int d(...);
+    public static int i(...);
+    public static int v(...);
+}

--- a/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt
@@ -2,11 +2,16 @@ package jp.co.yumemi.android.code_check
 
 import android.os.StrictMode
 import androidx.fragment.app.strictmode.FragmentStrictMode
+import timber.log.Timber
 
 /**
  * Debug ビルド時に適用するApplication クラス
  */
 class DebugApplication : MainApplication() {
+
+    /** Timber のログ出力ツリー */
+    override val timberTree = Timber.DebugTree()
+
 
     override fun onCreate() {
         // region: StrictMode の設定

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
@@ -1,5 +1,27 @@
 package jp.co.yumemi.android.code_check
 
 import android.app.Application
+import timber.log.Timber
 
-open class MainApplication : Application()
+open class MainApplication : Application() {
+
+    /** Timber のログ出力ツリー */
+    protected open val timberTree = object : Timber.Tree() {
+        override fun log(
+            priority: Int,
+            tag: String?,
+            message: String,
+            t: Throwable?,
+        ) {
+            // TODO: 必要に応じてログ出力先を設定する
+        }
+    }
+
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // Timber の設定
+        Timber.plant(timberTree)
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
@@ -4,13 +4,13 @@
 package jp.co.yumemi.android.code_check
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.databinding.FragmentTwoBinding
+import timber.log.Timber
 
 class TwoFragment : Fragment(R.layout.fragment_two) {
 
@@ -22,7 +22,7 @@ class TwoFragment : Fragment(R.layout.fragment_two) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        Log.d("検索した日時", lastSearchDate.toString())
+        Timber.tag("検索した日時").d(lastSearchDate.toString())
 
         binding = FragmentTwoBinding.bind(view)
 

--- a/docs/DevNotes.md
+++ b/docs/DevNotes.md
@@ -39,6 +39,8 @@
     * https://mvnrepository.com/artifact/com.squareup.leakcanary/leakcanary-android
 * Material Design
     * https://mvnrepository.com/artifact/com.google.android.material/material
+* Timber
+    * https://mvnrepository.com/artifact/com.jakewharton.timber/timber
 
 
 

--- a/variables.gradle
+++ b/variables.gradle
@@ -12,6 +12,7 @@ ext {
                     espresso: '3.5.1',
                     junit: '1.1.5',
                     uiautomator: '2.2.0',
-            ]
+            ],
+            timber: '5.0.1',
     ]
 }


### PR DESCRIPTION
* [x] 既存改良

## 概要



## 変更点
### 追加
* `Log.d()`, `Log.i()`, `Log.v()` を取り除くProGuard ルールの追加
* Timber の導入

### 修正
* `Log.*()` と記述していた箇所をTimber に差し替え



## 申し送り事項
後続タスクとして #29 などが見込まれるため、想定作業箇所に `TODO` を付与しています。



## 確認事項
* [ ] リリースビルドでTwoFragment 内のログ出力が表示されない



## 備考
### 見送ったこと
* [Logcatのソースへ飛ぶ機能をTimberに盛り込んでみた。 #Android - Qiita](https://qiita.com/shiraji/items/5815bfe667d042051119)

### 参考文献
* https://github.com/JakeWharton/timber
* [4. 安全にテクノロジーを活用する — Androidアプリのセキュア設計・セキュアコーディングガイド 2022-08-29 ドキュメント](https://www.jssec.org/dl/android_securecoding_20220829/4_using_technology_in_a_safe_way.html#system-out-err)