### PR TITLE
#43 + #44 UI 操作によって検索結果が消えてしまう問題の修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -24,7 +24,7 @@ class OneFragment: Fragment(R.layout.fragment_one){
 
         val _binding= FragmentOneBinding.bind(view)
 
-        val _viewModel= OneViewModel(context!!)
+        val _viewModel= OneViewModel()
 
         val _layoutManager= LinearLayoutManager(context!!)
         val _dividerItemDecoration=

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -11,20 +11,26 @@ import android.view.inputmethod.EditorInfo
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
 import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
+import kotlinx.coroutines.launch
 import java.net.UnknownHostException
 
 class OneFragment: Fragment(R.layout.fragment_one){
+
+    private val _viewModel by viewModels<OneViewModel>()
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?)
     {
         super.onViewCreated(view, savedInstanceState)
 
         val _binding= FragmentOneBinding.bind(view)
-
-        val _viewModel= OneViewModel()
 
         val _layoutManager= LinearLayoutManager(context!!)
         val _dividerItemDecoration=
@@ -41,9 +47,7 @@ class OneFragment: Fragment(R.layout.fragment_one){
                     editText.text.toString().also {
                         try {
                             if (it.isNotBlank()) {
-                                _viewModel.searchResults(it).apply {
-                                    _adapter.submitList(this)
-                                }
+                                _viewModel.searchResults(it)
                             } else {
                                 Toast.makeText(
                                     requireContext(),
@@ -68,6 +72,14 @@ class OneFragment: Fragment(R.layout.fragment_one){
             it.layoutManager= _layoutManager
             it.addItemDecoration(_dividerItemDecoration)
             it.adapter= _adapter
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                _viewModel.searchResult.collect {
+                    _adapter.submitList(it)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
@@ -13,6 +13,8 @@ import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -23,8 +25,14 @@ import java.util.*
  */
 class OneViewModel : ViewModel() {
 
+    private val _searchResult = MutableStateFlow(emptyList<item>())
+
+    /** 検索結果が流れてくるFlow */
+    val searchResult: StateFlow<List<item>> = _searchResult
+
+
     // 検索結果
-    fun searchResults(inputText: String): List<item> = runBlocking {
+    fun searchResults(inputText: String) = runBlocking {
         val client = HttpClient(Android)
 
         return@runBlocking GlobalScope.async {
@@ -67,7 +75,7 @@ class OneViewModel : ViewModel() {
 
             lastSearchDate = Date()
 
-            return@async items.toList()
+            _searchResult.value = items
         }.await()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
@@ -3,7 +3,6 @@
  */
 package jp.co.yumemi.android.code_check
 
-import android.content.Context
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import io.ktor.client.*
@@ -22,9 +21,7 @@ import java.util.*
 /**
  * TwoFragment で使う
  */
-class OneViewModel(
-    val context: Context
-) : ViewModel() {
+class OneViewModel : ViewModel() {
 
     // 検索結果
     fun searchResults(inputText: String): List<item> = runBlocking {
@@ -59,7 +56,7 @@ class OneViewModel(
                     item(
                         name = name,
                         ownerIconUrl = ownerIconUrl,
-                        language = context.getString(R.string.written_language, language),
+                        language = language,
                         stargazersCount = stargazersCount,
                         watchersCount = watchersCount,
                         forksCount = forksCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TwoFragment.kt
@@ -30,7 +30,7 @@ class TwoFragment : Fragment(R.layout.fragment_two) {
 
         _binding.ownerIconView.load(item.ownerIconUrl);
         _binding.nameView.text = item.name;
-        _binding.languageView.text = item.language;
+        _binding.languageView.text = getString(R.string.written_language, item.language)
         _binding.starsView.text = "${item.stargazersCount} stars";
         _binding.watchersView.text = "${item.watchersCount} watchers";
         _binding.forksView.text = "${item.forksCount} forks";

--- a/variables.gradle
+++ b/variables.gradle
@@ -2,7 +2,7 @@ ext {
     // アプリバージョン
     def appVersionMajor = 1
     def appVersionMinor = 0
-    def appVersionPatch = 3
+    def appVersionPatch = 4
     appVersionCode = 10000 * appVersionMajor + 100 * appVersionMinor + appVersionPatch
     appVersionName = "${appVersionMajor}.${appVersionMinor}.${appVersionPatch}"
 }


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#43, #44 で報告のあった事象に対して修正を行いました。

#43 画面回転 | #44 画面遷移 |  | 本PR の修正結果
:---: | :---: | :---: | :---:
[rotate_before.webm](https://github.com/tshion/yumemi-inc_android-engineer-codecheck/assets/29895868/6b651188-bbea-4f29-a1a6-8826365ba6d8) | [navigation_before.webm](https://github.com/tshion/yumemi-inc_android-engineer-codecheck/assets/29895868/6b2f0848-6748-4f43-b1c8-fa2f21a399ef) | -> | [after.webm](https://github.com/tshion/yumemi-inc_android-engineer-codecheck/assets/29895868/910f23f7-39be-4907-8340-d08af892f2b5)



## 変更点
### 修正
* `StateFlow` を使って、画面回転や遷移を行っても、検索結果が維持されるように修正
* アプリバージョンの更新
* 軽微なリファクタリング
    * `OneViewModel` の生成方法の修正



## 申し送り事項
* 詳細画面が見切れる件は #53 で別途取り扱い予定



## 確認事項
* [ ] 検索実行後、端末を回転させても、検索結果が維持されている
* [ ] 詳細画面に遷移後、プログラミング言語の表示が、本PR 以前のアプリ表示と一致している
* [ ] 詳細画面から一覧画面に戻った際、検索結果が維持されている
* [ ] アプリのバージョンを確認すると1.0.4 である



## 備考
### 参考文献
* [StateFlow と SharedFlow  |  Kotlin  |  Android Developers](https://developer.android.com/kotlin/flow/stateflow-and-sharedflow)
* [UI の状態を保存する  |  Android デベロッパー  |  Android Developers](https://developer.android.com/topic/libraries/architecture/saving-states)
* [ライフサイクル対応コンポーネントで Kotlin コルーチンを使用する  |  Android デベロッパー  |  Android Developers](https://developer.android.com/topic/libraries/architecture/coroutines)
