### PR TITLE
#57 targetSdk を31 -> 34 へ更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ try {
 
 android {
     namespace 'jp.co.yumemi.android.code_check'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
         minSdk 23
-        targetSdk 33
+        targetSdk 34
         versionCode appVersionCode
         versionName appVersionName
 
@@ -55,11 +55,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '17'
     }
     buildFeatures {
         viewBinding true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ try {
 
 android {
     namespace 'jp.co.yumemi.android.code_check'
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
         minSdk 23
-        targetSdk 31
+        targetSdk 32
         versionCode appVersionCode
         versionName appVersionName
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ try {
 
 android {
     namespace 'jp.co.yumemi.android.code_check'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
         minSdk 23
-        targetSdk 32
+        targetSdk 33
         versionCode appVersionCode
         versionName appVersionName
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
 


### PR DESCRIPTION
* [x] 既存改良

## 概要
targetSdk を31 -> 34 へ更新し、それに付随してJava 設定やGradle プラグインのバージョンも更新しました。



## 変更点
### 修正
* Gradle プラグインの更新: 8.0.2 -> 8.1.2
* Java 関連設定の更新: 11 -> 17
* targetSdk の更新



## 確認事項
* [ ] UI 自動テスト`HappyPathUiTest` が正常終了する



## 備考
### 参考文献
* [Java versions in Android builds  |  Android Studio  |  Android Developers](https://developer.android.com/build/jdks?hl=en)
* [Minimum versions of tools for Android API level](https://developer.android.com/build/releases/gradle-plugin?hl=en#api-level-support)
