### PR TITLE
#61 Gradle の記述ブラッシュアップ

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,43 +75,44 @@ android {
 dependencies {
 
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:${libver.androidx.espresso}"
-    androidTestImplementation "androidx.test.espresso:espresso-core:${libver.androidx.espresso}"
-    androidTestImplementation "androidx.test.ext:junit-ktx:${libver.androidx.junit}"
-    androidTestImplementation "androidx.test.uiautomator:uiautomator:${libver.androidx.uiautomator}"
+    implementation "${libraries.androidx.appcompat}"
+    implementation "${libraries.androidx.constraintlayout}"
+    implementation "${libraries.androidx.core}"
+    androidTestImplementation "${libraries.androidx.espresso.contrib}"
+    androidTestImplementation "${libraries.androidx.espresso.core}"
+    androidTestImplementation "${libraries.androidx.junit}"
+    implementation "${libraries.androidx.lifecycle.runtime}"
+    implementation "${libraries.androidx.lifecycle.viewmodel}"
+    implementation "${libraries.androidx.navigation.fragment}"
+    implementation "${libraries.androidx.navigation.ui}"
+    implementation "${libraries.androidx.recyclerview}"
+    androidTestImplementation "${libraries.androidx.uiautomator}"
 
     // Coil
-    implementation 'io.coil-kt:coil:1.3.2'
+    implementation "${libraries.coil}"
 
     // Firebase
-    releaseImplementation platform('com.google.firebase:firebase-bom:32.5.0')
-    releaseImplementation("com.google.firebase:firebase-crashlytics")
+    releaseImplementation platform("${libraries.firebase.bom}")
+    releaseImplementation("${libraries.firebase.crashlytics}")
 
     // JUnit
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation "${libraries.junit}"
 
     // Kotlin Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
+    implementation "${libraries.coroutines.bom}"
+    implementation "${libraries.coroutines.android}"
 
     // Ktor
-    implementation 'io.ktor:ktor-client-android:1.6.4'
+    implementation "${libraries.ktor}"
 
     // LeakCanary
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
+    debugImplementation "${libraries.leakCanary}"
 
     // Material Design
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation "${libraries.material}"
 
     // Timber
-    implementation "com.jakewharton.timber:timber:${libver.timber}"
+    implementation "${libraries.timber}"
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,12 +23,12 @@ try {
 
 android {
     namespace 'jp.co.yumemi.android.code_check'
-    compileSdk 34
+    compileSdk targetSdkVersion
 
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
-        minSdk 23
-        targetSdk 34
+        minSdk minSdkVersion
+        targetSdk targetSdkVersion
         versionCode appVersionCode
         versionName appVersionName
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,9 @@ android {
     namespace 'jp.co.yumemi.android.code_check'
     compileSdk targetSdkVersion
 
+    buildFeatures {
+        viewBinding true
+    }
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
         minSdk minSdkVersion
@@ -66,9 +69,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '17'
-    }
-    buildFeatures {
-        viewBinding true
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,38 +74,42 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.6.0'
+    // AndroidX
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
-
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
-    implementation 'io.ktor:ktor-client-android:1.6.4'
-
-    implementation 'io.coil-kt:coil:1.3.2'
-
-    testImplementation 'junit:junit:4.13.2'
-
-    // AndroidX
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
     androidTestImplementation "androidx.test.espresso:espresso-contrib:${libver.androidx.espresso}"
     androidTestImplementation "androidx.test.espresso:espresso-core:${libver.androidx.espresso}"
     androidTestImplementation "androidx.test.ext:junit-ktx:${libver.androidx.junit}"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:${libver.androidx.uiautomator}"
 
+    // Coil
+    implementation 'io.coil-kt:coil:1.3.2'
+
     // Firebase
     releaseImplementation platform('com.google.firebase:firebase-bom:32.5.0')
     releaseImplementation("com.google.firebase:firebase-crashlytics")
 
+    // JUnit
+    testImplementation 'junit:junit:4.13.2'
+
+    // Kotlin Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
+
+    // Ktor
+    implementation 'io.ktor:ktor-client-android:1.6.4'
+
     // LeakCanary
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
+
+    // Material Design
+    implementation 'com.google.android.material:material:1.4.0'
 
     // Timber
     implementation "com.jakewharton.timber:timber:${libver.timber}"

--- a/build.gradle
+++ b/build.gradle
@@ -2,24 +2,21 @@
 buildscript {
     // Local variables
     apply from: 'variables.gradle'
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
-
-        // Firebase
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
-
-        // Google GMS Google Services Gradle Plugin
-        classpath "com.google.gms:google-services:4.4.0"
-    }
 }
 
-tasks.register('clean', Delete) {
-    delete rootProject.buildDir
+plugins {
+    // Android Gradle Plugin
+    id 'com.android.application' version '8.1.2' apply false
+
+    // AndroidX Navigation
+    id 'androidx.navigation.safeargs' version '2.5.3' apply false
+
+    // Firebase
+    id 'com.google.firebase.crashlytics' version '2.9.9' apply false
+
+    // Google GMS Google Services Gradle Plugin
+    id 'com.google.gms.google-services' version '4.4.0' apply false
+
+    // Kotlin
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }

--- a/docs/DevNotes.md
+++ b/docs/DevNotes.md
@@ -8,7 +8,6 @@
         * https://mvnrepository.com/artifact/androidx.test.espresso/espresso-contrib
         * https://mvnrepository.com/artifact/androidx.test.espresso/espresso-core
     * lifecycle
-        * https://mvnrepository.com/artifact/androidx.lifecycle/lifecycle-livedata-ktx
         * https://mvnrepository.com/artifact/androidx.lifecycle/lifecycle-runtime-ktx
         * https://mvnrepository.com/artifact/androidx.lifecycle/lifecycle-viewmodel-ktx
     * navigation

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,13 +12,15 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
+# Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true
 
 # Gradle Build Cache
 org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
+
 rootProject.name = "Android Engineer CodeCheck"
 include ':app'

--- a/variables.gradle
+++ b/variables.gradle
@@ -7,12 +7,43 @@ ext {
     appVersionName = "${appVersionMajor}.${appVersionMinor}.${appVersionPatch}"
 
     // ライブラリバージョン
-    libver = [
-            androidx: [
-                    espresso: '3.5.1',
-                    junit: '1.1.5',
-                    uiautomator: '2.2.0',
+    def versionEspresso = '3.5.1'
+    def versionLifecycle = '2.5.1'
+    def versionNavigation = '2.5.3'
+    libraries = [
+            androidx  : [
+                    appcompat       : 'androidx.appcompat:appcompat:1.3.1',
+                    constraintlayout: 'androidx.constraintlayout:constraintlayout:2.1.1',
+                    core            : 'androidx.core:core-ktx:1.6.0',
+                    espresso        : [
+                            contrib: "androidx.test.espresso:espresso-contrib:${versionEspresso}",
+                            core   : "androidx.test.espresso:espresso-core:${versionEspresso}",
+                    ],
+                    junit           : 'androidx.test.ext:junit-ktx:1.1.5',
+                    lifecycle       : [
+                            runtime  : "androidx.lifecycle:lifecycle-runtime-ktx:${versionLifecycle}",
+                            viewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${versionLifecycle}",
+                    ],
+                    navigation      : [
+                            fragment: "androidx.navigation:navigation-fragment-ktx:${versionNavigation}",
+                            ui      : "androidx.navigation:navigation-ui-ktx:${versionNavigation}",
+                    ],
+                    recyclerview    : 'androidx.recyclerview:recyclerview:1.2.1',
+                    uiautomator     : 'androidx.test.uiautomator:uiautomator:2.2.0',
             ],
-            timber: '5.0.1',
+            coil      : 'io.coil-kt:coil:1.3.2',
+            coroutines: [
+                    bom    : 'org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.1',
+                    android: 'org.jetbrains.kotlinx:kotlinx-coroutines-android',
+            ],
+            firebase  : [
+                    bom        : 'com.google.firebase:firebase-bom:32.5.0',
+                    crashlytics: 'com.google.firebase:firebase-crashlytics',
+            ],
+            junit     : 'junit:junit:4.13.2',
+            ktor      : 'io.ktor:ktor-client-android:1.6.4',
+            leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.12',
+            material  : 'com.google.android.material:material:1.4.0',
+            timber    : 'com.jakewharton.timber:timber:5.0.1',
     ]
 }

--- a/variables.gradle
+++ b/variables.gradle
@@ -1,4 +1,8 @@
 ext {
+    // アプリ構成
+    minSdkVersion = 23
+    targetSdkVersion = 34
+
     // アプリバージョン
     def appVersionMajor = 1
     def appVersionMinor = 1


### PR DESCRIPTION
* [x] 既存改良

## 概要
#61 の対応を行いました。



## 変更点
### 削除
* ライブラリlifecycle-livedata-ktx の依存削除
    * 利用箇所が見つからなかったため

### 修正
* SDK バージョン指定の変数化
* 依存ライブラリの記述ブラッシュアップ
* 記述構成のブラッシュアップ
    * Android Studio Giraffe Patch 2 でプロジェクト新規作成した時と同じ記述構成に揃えました



## 確認事項
* [ ] GitHub Actions で実行しているGradle タスクが実行できる
* [ ] UI 自動テスト"HappyPath" が正常終了する



## 備考
### 参考文献
* https://stackoverflow.com/questions/53921194/plugin-with-id-androidx-navigation-safeargs-not-found
