### PR TITLE
PR #62 のコミット漏れを追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,15 +23,15 @@ try {
 
 android {
     namespace 'jp.co.yumemi.android.code_check'
-    compileSdk targetSdkVersion
+    compileSdk androidApi.target
 
     buildFeatures {
         viewBinding true
     }
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
-        minSdk minSdkVersion
-        targetSdk targetSdkVersion
+        minSdk androidApi.min
+        targetSdk androidApi.target
         versionCode appVersionCode
         versionName appVersionName
 

--- a/variables.gradle
+++ b/variables.gradle
@@ -1,7 +1,9 @@
 ext {
     // アプリ構成
-    minSdkVersion = 23
-    targetSdkVersion = 34
+    androidApi = [
+            min: 23,
+            target: 34,
+    ]
 
     // アプリバージョン
     def appVersionMajor = 1


### PR DESCRIPTION
## 概要
#62 でコミット漏れがあったので、本PR で追加しました。

### 補足
#62 をビルドすると、minSdk とtargetSdk がうまく適用されず、指定したバージョンより低いものが適用されます。

その様子はapp -> AndroidManifest.xml で"Merged Manifest" を見ると分かりやすいかと思います。



## 変更点
### 修正
* Android API level の変数の記述調整



## 確認事項
* [ ] ビルドが出来る



## 備考
* 特になし
