### PR TITLE
#72 Hyperion の導入

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -5,6 +5,16 @@
 
 
 ## 開発メモ
+### 開発時にアプリ上で使える便利機能
+[Hyperion](https://github.com/willowtreeapps/Hyperion-Android) を組み込んだため、
+debug ビルドでアプリ実行した際に下記の機能を利用できます。
+
+通知権限を許可した状態でOS 通知欄をタップするか、端末を振ってHyperion メニューを表示してください。
+
+* Timber 出力の確認
+* View 間の距離計測
+* View の属性確認
+
 ### ビルドタイプによる実装の違い
 | | debug<br />(開発作業用) | release<br />(ストアリリース用)
 --- | :---: | :---:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,12 @@ dependencies {
     releaseImplementation platform("${libraries.firebase.bom}")
     releaseImplementation("${libraries.firebase.crashlytics}")
 
+    // Hyperion
+    debugImplementation "${libraries.hyperion.attr}"
+    debugImplementation "${libraries.hyperion.core}"
+    debugImplementation "${libraries.hyperion.measurement}"
+    debugImplementation "${libraries.hyperion.timber}"
+
     // JUnit
     testImplementation "${libraries.junit}"
 

--- a/variables.gradle
+++ b/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     // アプリ構成
     androidApi = [
-            min: 23,
+            min   : 23,
             target: 34,
     ]
 
@@ -14,6 +14,7 @@ ext {
 
     // ライブラリバージョン
     def versionEspresso = '3.5.1'
+    def versionHyperion = '0.9.37'
     def versionLifecycle = '2.5.1'
     def versionNavigation = '2.5.3'
     libraries = [
@@ -45,6 +46,12 @@ ext {
             firebase  : [
                     bom        : 'com.google.firebase:firebase-bom:32.5.0',
                     crashlytics: 'com.google.firebase:firebase-crashlytics',
+            ],
+            hyperion  : [
+                    attr       : "com.willowtreeapps.hyperion:hyperion-attr:$versionHyperion",
+                    core       : "com.willowtreeapps.hyperion:hyperion-core:$versionHyperion",
+                    measurement: "com.willowtreeapps.hyperion:hyperion-measurement:$versionHyperion",
+                    timber     : "com.willowtreeapps.hyperion:hyperion-timber:$versionHyperion",
             ],
             junit     : 'junit:junit:4.13.2',
             ktor      : 'io.ktor:ktor-client-android:1.6.4',


### PR DESCRIPTION
* [x] 新規追加

## 概要
Hyperion を導入し、アプリ上で開発支援機能を使えるようにしました。



## 変更点
### 追加
* Hyperion プラグインの追加



## 確認事項
Android 13 以降では、通知権限を許可した状態で試すと分かりやすいかもです。

* [ ] debug ビルドでアプリ実行すると、Hyperion メニューを表示できる
* [ ] "Timber" をタップすると、Timber のログ出力を確認できる



## 備考
* https://github.com/willowtreeapps/Hyperion-Android
* https://mvnrepository.com/artifact/com.willowtreeapps.hyperion
