### PR TITLE
#49 ローディングUI の実装

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/atoms/LoadingOverlay.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/atoms/LoadingOverlay.kt
@@ -16,7 +16,7 @@ import jp.co.yumemi.android.code_check.R
  *
  * ``` xml
  * <FrameLayout>
- *     <!-- ローディングを行っているものを表示するView -->
+ *     <!-- 表示に時間がかかるView -->
  *     <View />
  *
  *     <!-- ローディング表示 -->

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/atoms/LoadingOverlay.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/atoms/LoadingOverlay.kt
@@ -1,0 +1,52 @@
+package jp.co.yumemi.android.code_check.atoms
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.FrameLayout
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import jp.co.yumemi.android.code_check.R
+
+/**
+ * ローディングUI
+ *
+ * ## 使い方
+ * 表示に時間がかかるView に被せるように配置してください。
+ *
+ * ``` xml
+ * <FrameLayout>
+ *     <!-- ローディングを行っているものを表示するView -->
+ *     <View />
+ *
+ *     <!-- ローディング表示 -->
+ *     <(package).LoadingOverlay />
+ * </FrameLayout>
+ * ```
+ */
+class LoadingOverlay @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : FrameLayout(context, attrs) {
+
+    init {
+        // Note: このView でタップイベントを奪い、下に配置したView に伝搬しないようにする
+        isClickable = true
+        isFocusable = true
+
+        setBackgroundResource(R.color.app_transparent_shadow)
+
+        // ローディングの配置
+        addView(
+            CircularProgressIndicator(context).apply {
+                isIndeterminate = true
+                setIndicatorColor(resources.getColor(R.color.app_accent, null))
+            },
+            LayoutParams(
+                WRAP_CONTENT,
+                WRAP_CONTENT,
+                Gravity.CENTER,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
* [x] 新規追加

## 概要
ローディングUI の実装を追加しました。

本PR には含めていませんが、サンプルとして実装した時の様子は下記となります。
<img width="240" src="https://github.com/tshion/yumemi-inc_android-engineer-codecheck/assets/29895868/6611eed2-17a7-4616-a842-e6b441ce3ea6" />



## 変更点
### 追加
* ローディングUI の追加



## 確認事項
Android Studio で該当実装を開いて、プレビューを確認してください。
各画面の組み込み前なので、軽めとなっています。

* [ ] 背景色が黒っぽい透過である
* [ ] インジケータがアクセントカラーっぽい



## 備考
* https://m2.material.io/components/progress-indicators
