### PR TITLE
#78 1つの文言を表示するリスト項目UI の追加

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/FloatExtensions.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/FloatExtensions.kt
@@ -1,0 +1,15 @@
+package jp.co.yumemi.android.code_check
+
+import android.content.res.Resources
+
+
+/**
+ * dp からpx へ変換
+ *
+ * * Jetpack Compose では同様機能が提供されているので、本メソッドを使わないでください
+ * * [参考文献](https://developer.android.com/training/multiscreen/screendensities#dips-pels)
+ */
+fun Float.toPx(resources: Resources): Int {
+    val scale: Float = resources.displayMetrics.density
+    return (this * scale + 0.5f).toInt()
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/molecules/SimpleListItemView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/molecules/SimpleListItemView.kt
@@ -1,0 +1,81 @@
+package jp.co.yumemi.android.code_check.molecules
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import androidx.appcompat.content.res.AppCompatResources.getDrawable
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.toPx
+
+/**
+ * 1つの文言を表示するリスト項目UI
+ *
+ * ## 使い方
+ * `RecyclerView` のリスト項目として使ってください。
+ * `RecyclerView.Adapter` での実装例は下記となります。
+ *
+ * ``` kotlin
+ * class ???Adapter : RecyclerView.Adapter<SimpleListItemView.ViewHolder>() {
+ *     // (省略)
+ *
+ *     override fun onCreateViewHolder(
+ *         parent: ViewGroup,
+ *         viewType: Int,
+ *     ) = SimpleListItemView(parent.context).apply {
+ *         layoutParams = LayoutParams(
+ *             MATCH_PARENT,
+ *             WRAP_CONTENT,
+ *         )
+ *     }.let { SimpleListItemView.ViewHolder(it) }
+ *
+ *     override fun onBindViewHolder(
+ *         holder: SimpleListItemView.ViewHolder,
+ *         position: Int,
+ *     ) {
+ *         holder.view.text = "set text"
+ *     }
+ *
+ *     // (省略)
+ * }
+ * ```
+ */
+class SimpleListItemView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : AppCompatTextView(context, attrs) {
+
+    init {
+        val paddingH = 16f.toPx(resources)
+        val paddingV = 8f.toPx(resources)
+        setPadding(paddingH, paddingV, paddingH, paddingV)
+        isClickable = true
+
+
+        setBackgroundResource(R.color.app_base)
+
+        // ripple 効果の設定
+        // 参考文献: https://stackoverflow.com/a/48884995
+        foreground = getDrawable(
+            context,
+            TypedValue().apply {
+                context.theme.resolveAttribute(
+                    android.R.attr.selectableItemBackground,
+                    this,
+                    true,
+                )
+            }.resourceId,
+        )
+
+
+        setTextColor(ContextCompat.getColor(context, R.color.app_base_on))
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+    }
+
+
+    class ViewHolder(
+        val view: SimpleListItemView,
+    ) : RecyclerView.ViewHolder(view)
+}


### PR DESCRIPTION
* [x] 新規追加

## 概要
下記の機能を備えた、 1つの文言を表示するリスト項目UI を追加しました。

* Ripple 付き
* ダークモード対応



## 変更点
### 追加
*  1つの文言を表示するリスト項目UI の追加
* dp -> px 変換するユーティリティーメソッドの追加



## 確認事項
※本格的な確認は、各画面に組み込んだ際に依頼したいです。

* [ ] 実装面で不備が無さそう



## 備考
* プログラムでripple 設定をする方法: https://stackoverflow.com/a/48884995
