### PR TITLE
#79 画面タイトルを表示するツールバーの追加

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/molecules/SimpleToolbar.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/molecules/SimpleToolbar.kt
@@ -1,0 +1,54 @@
+package jp.co.yumemi.android.code_check.molecules
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupWithNavController
+import jp.co.yumemi.android.code_check.R
+
+/**
+ * 画面タイトルを表示するツールバー
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ *
+ * ## 使い方
+ * 画面UI にこのツールバーを配置し、コードから `setupWith(NavController)` を呼び出してください。
+ *
+ * ``` xml
+ * <???>
+ *     <!-- 省略 -->
+ *     <package.SimpleToolbar
+ *         android:id="@+id/???"
+ *         android:layout_width="match_parent"
+ *         android:layout_height="?actionBarSize" />
+ *     <!-- 省略 -->
+ * </???>
+ * ```
+ */
+class SimpleToolbar @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : Toolbar(context, attrs) {
+
+    init {
+        setBackgroundResource(R.color.app_main)
+        setTitleTextColor(ContextCompat.getColor(context, R.color.app_main_on))
+    }
+
+
+    /**
+     * Jetpack Navigation コンポーネントを使って表示をセットアップ
+     *
+     * * [参考文献](https://developer.android.com/guide/navigation/navigation-ui#create_a_toolbar)
+     */
+    fun setupWith(navController: NavController) {
+        setupWithNavController(
+            navController,
+            AppBarConfiguration(navController.graph),
+        )
+    }
+}


### PR DESCRIPTION
* [x] 新規追加

## 概要
タイトルを表示するツールバーを追加しました。

Jetpack Navigation コンポーネントの下記機能を利用し、表示を形作っています。

* タイトル -> ナビゲーション定義の `android:label`
* 戻るボタンの制御 -> ライブラリの機能



## 変更点
### 追加
* ツールバーの追加



## 確認事項
※本格的な確認は、各画面に組み込んだ際に依頼したいです。

* [ ] 実装面で不備が無さそう



## 備考
* https://developer.android.com/guide/navigation/navigation-ui#create_a_toolbar
* https://developer.android.com/guide/fragments/appbar#fragment