### PR TITLE
#50 + #90 リトライダイアログと、debug ビルドで手軽に表示できる機構の追加

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -72,10 +72,12 @@ Git 管理から外しているため、試す際は追加でセットアップ�
         * [OkHttp](https://github.com/square/okhttp)
     * [Timber](https://github.com/JakeWharton/timber) ([Maven Central](https://mvnrepository.com/artifact/com.jakewharton.timber/timber))
 * 開発設定
+    * [AutoService](https://github.com/google/auto/tree/main/service) ([Maven Central](https://mvnrepository.com/artifact/com.google.auto.service/auto-service))
     * [Hyperion]
         * Hyperion-Attr ([Maven Central](https://mvnrepository.com/artifact/com.willowtreeapps.hyperion/hyperion-attr))
         * [Hyperion-Core](https://github.com/willowtreeapps/Hyperion-Android/tree/develop/hyperion-core) ([Maven Central](https://mvnrepository.com/artifact/com.willowtreeapps.hyperion/hyperion-core))
         * Hyperion-Measurement ([Maven Central](https://mvnrepository.com/artifact/com.willowtreeapps.hyperion/hyperion-measurement))
+        * Hyperion-Plugin ([Maven Central](https://mvnrepository.com/artifact/com.willowtreeapps.hyperion/hyperion-plugin))
         * [Hyperion-Timber](https://github.com/willowtreeapps/Hyperion-Android/tree/develop/hyperion-timber) ([Maven Central](https://mvnrepository.com/artifact/com.willowtreeapps.hyperion/hyperion-timber))
     * [LeakCanary](https://github.com/square/leakcanary) ([Maven Central](https://mvnrepository.com/artifact/com.squareup.leakcanary/leakcanary-android))
     * OkHttp BOM

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     implementation "${libraries.androidx.recyclerview}"
     androidTestImplementation "${libraries.androidx.uiautomator}"
 
+    // Auto Service
+    kaptDebug "${libraries.autoservice}"
+
     // Coil
     implementation "${libraries.coil}"
 
@@ -103,6 +106,7 @@ dependencies {
     debugImplementation "${libraries.hyperion.attr}"
     debugImplementation "${libraries.hyperion.core}"
     debugImplementation "${libraries.hyperion.measurement}"
+    debugImplementation "${libraries.hyperion.plugin}"
     debugImplementation "${libraries.hyperion.timber}"
 
     // JUnit

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/ShowRetryDialogHyperionPlugin.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/ShowRetryDialogHyperionPlugin.kt
@@ -1,0 +1,46 @@
+package jp.co.yumemi.android.code_check
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.navigation.findNavController
+import com.google.auto.service.AutoService
+import com.willowtreeapps.hyperion.plugin.v1.Plugin
+import com.willowtreeapps.hyperion.plugin.v1.PluginModule
+import jp.co.yumemi.android.code_check.molecules.HyperionMenuItemView
+import jp.co.yumemi.android.code_check.templates.RetryDialogFragmentDirections
+
+/**
+ * リトライダイアログを表示するHyperion Plugin
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ */
+@AutoService(Plugin::class)
+class ShowRetryDialogHyperionPlugin : Plugin() {
+
+    override fun createPluginModule() = object : PluginModule() {
+
+        override fun createPluginView(
+            layoutInflater: LayoutInflater,
+            parent: ViewGroup,
+        ) = HyperionMenuItemView(parent.context).apply {
+            setName(name)
+            setOnClickListener {
+                try {
+                    val direction = RetryDialogFragmentDirections.navShowRetryDialog(
+                        title = "タイトル from Hyperion",
+                        message = "メッセージ from Hyperion",
+                    )
+                    extension.activity
+                        .findNavController(R.id.nav_host_fragment)
+                        .navigate(direction)
+                } catch (e: Exception) {
+                    Toast.makeText(parent.context, "表示できません", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
+        override fun getName() = R.string.hyperion_show_retry_dialog_title
+    }
+}

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
@@ -17,10 +17,24 @@ import androidx.core.view.setPadding
 import androidx.core.widget.ImageViewCompat
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.toPx
+
 import com.willowtreeapps.hyperion.plugin.R as HyperionR
 
 /**
  * Hyperion のメニュー項目UI
+ *
+ * ## 使用条件
+ * * Hyperion を利用している
+ *
+ * ## 使い方
+ * ``` kotlin
+ * HyperionMenuItemView(context).apply {
+ *     setName(resId)
+ *     setOnClickListener {
+ *         // TODO
+ *     }
+ * }
+ * ```
  *
  * ## 参考文献
  * * [Hyperion Timber のメニュー項目の実装](https://github.com/willowtreeapps/Hyperion-Android/blob/develop/hyperion-timber/src/main/res/layout/tmb_item_plugin.xml)

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
@@ -1,0 +1,94 @@
+package jp.co.yumemi.android.code_check.molecules
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.LinearLayout
+import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.appcompat.widget.LinearLayoutCompat
+import androidx.core.content.ContextCompat
+import androidx.core.view.setPadding
+import androidx.core.widget.ImageViewCompat
+import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.toPx
+import com.willowtreeapps.hyperion.plugin.R as HyperionR
+
+/**
+ * Hyperion のメニュー項目UI
+ *
+ * ## 参考文献
+ * * [Hyperion Timber のメニュー項目の実装](https://github.com/willowtreeapps/Hyperion-Android/blob/develop/hyperion-timber/src/main/res/layout/tmb_item_plugin.xml)
+ */
+class HyperionMenuItemView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : LinearLayoutCompat(context, attrs) {
+
+    private val nameTextView: AppCompatTextView
+
+
+    init {
+        foreground = AppCompatResources.getDrawable(
+            context,
+            TypedValue().apply {
+                context.theme.resolveAttribute(
+                    android.R.attr.selectableItemBackground,
+                    this,
+                    true,
+                )
+            }.resourceId,
+        )
+        gravity = Gravity.CENTER_VERTICAL
+        minimumHeight = 131f.toPx(resources)
+        orientation = HORIZONTAL
+        setPadding(
+            resources.getDimensionPixelSize(HyperionR.dimen.hype_plugin_padding)
+        )
+
+
+        val colorSelector = ContextCompat.getColor(
+            context,
+            HyperionR.color.hype_plugin_color_selector,
+        )
+
+        // アイコン表示
+        val imageView = AppCompatImageView(context).apply {
+            val size = resources.getDimensionPixelSize(HyperionR.dimen.hype_plugin_icon_size)
+            val spaceH = 28f.toPx(resources)
+
+            adjustViewBounds = true
+            isDuplicateParentStateEnabled = true
+            layoutParams = LayoutParams(size, size).apply {
+                setMargins(0, 0, spaceH, 0)
+            }
+            setImageResource(R.drawable.ic_launcher_foreground)
+            ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(colorSelector))
+        }
+
+        // 項目名
+        nameTextView = AppCompatTextView(context).apply {
+            isDuplicateParentStateEnabled = true
+            layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1f)
+            setTextColor(colorSelector)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
+        }
+
+        // 子View の追加
+        addView(imageView)
+        addView(nameTextView)
+    }
+
+
+    /**
+     * 項目名の設定
+     */
+    fun setName(@StringRes id: Int) {
+        nameTextView.setText(id)
+    }
+}

--- a/app/src/debug/res/values/hyperion.xml
+++ b/app/src/debug/res/values/hyperion.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="hyperion_show_retry_dialog_title">リトライダイアログの表示</string>
+</resources>

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
@@ -12,6 +12,9 @@ import jp.co.yumemi.android.code_check.R
 /**
  * リトライ可能な際に表示するダイアログ
  *
+ * ダイアログの選択結果は、Jetpack Navigation の[NavBackStackEntry] 経由で下記を通知します。
+ * 選択結果を利用したい場合は、ダイアログ呼び出しの前に、受け取り側の準備を行ってください、
+ *
  * * 「リトライ」ボタンをタップ: `true` が通知される
  * * 「キャンセル」ボタン or 領域外をタップ: `false` が通知される
  *
@@ -20,9 +23,6 @@ import jp.co.yumemi.android.code_check.R
  * * Kotlin Flow を利用している
  *
  * ## 使い方
- * Jetpack Navigation の[NavBackStackEntry] 経由で選択結果を受け渡しているので、
- * 受け取り側の準備 → ダイアログの呼び出しという手順が必要です。
- *
  * 1. 受け取り側の準備(例: Fragment)
  *     ``` kotlin
  *     viewLifecycleOwner.lifecycleScope.launch {
@@ -43,6 +43,11 @@ import jp.co.yumemi.android.code_check.R
  *         message = "TODO: Set Message",
  *     ).also { findNavController().navigate(it) }
  *     ```
+ *
+ * ## 注意事項
+ * * ダイアログ外に黒透過の背景が無いなどがあれば、まずはOS 標準のダイアログと見比べてください
+ *     * OS 標準のダイアログを表示するには、アプリアンインストールを試すのが手軽です
+ *     * エミュレーターのバグで、上手く表示できない事例があるようなので、色々な端末で見比べてください
  *
  * ## 参考文献
  * * [Returning a result to the previous Destination](https://developer.android.com/guide/navigation/use-graph/programmatic?hl=en#returning_a_result)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
@@ -26,7 +26,7 @@ import jp.co.yumemi.android.code_check.R
  * 1. 受け取り側の準備(例: Fragment)
  *     ``` kotlin
  *     viewLifecycleOwner.lifecycleScope.launch {
- *         repeatOnLifecycle(Lifecycle.State.STARTED) {
+ *         repeatOnLifecycle(Lifecycle.State.CREATED) {
  *             findNavController().currentBackStackEntry
  *                 ?.savedStateHandle
  *                 ?.getStateFlow(RetryDialogFragment.KEY_RESULT, false)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/RetryDialogFragment.kt
@@ -1,0 +1,86 @@
+package jp.co.yumemi.android.code_check.templates
+
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import jp.co.yumemi.android.code_check.R
+
+/**
+ * リトライ可能な際に表示するダイアログ
+ *
+ * * 「リトライ」ボタンをタップ: `true` が通知される
+ * * 「キャンセル」ボタン or 領域外をタップ: `false` が通知される
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ * * Kotlin Flow を利用している
+ *
+ * ## 使い方
+ * Jetpack Navigation の[NavBackStackEntry] 経由で選択結果を受け渡しているので、
+ * 受け取り側の準備 → ダイアログの呼び出しという手順が必要です。
+ *
+ * 1. 受け取り側の準備(例: Fragment)
+ *     ``` kotlin
+ *     viewLifecycleOwner.lifecycleScope.launch {
+ *         repeatOnLifecycle(Lifecycle.State.STARTED) {
+ *             findNavController().currentBackStackEntry
+ *                 ?.savedStateHandle
+ *                 ?.getStateFlow(RetryDialogFragment.KEY_RESULT, false)
+ *                 ?.collect {
+ *                     // TODO: 処理の記述
+ *                 }
+ *         }
+ *     }
+ *     ```
+ * 1. このダイアログを呼び出す
+ *     ``` kotlin
+ *     RetryDialogFragmentDirections.navShowRetryDialog(
+ *         title = "TODO: Set Title",
+ *         message = "TODO: Set Message",
+ *     ).also { findNavController().navigate(it) }
+ *     ```
+ *
+ * ## 参考文献
+ * * [Returning a result to the previous Destination](https://developer.android.com/guide/navigation/use-graph/programmatic?hl=en#returning_a_result)
+ * * [StateFlow and SharedFlow](https://developer.android.com/kotlin/flow/stateflow-and-sharedflow)
+ */
+class RetryDialogFragment : DialogFragment() {
+
+    private val args by navArgs<RetryDialogFragmentArgs>()
+
+
+    override fun onCreateDialog(
+        savedInstanceState: Bundle?,
+    ) = MaterialAlertDialogBuilder(requireContext(), R.style.ThemeOverlay_App_Dialog)
+        .setTitle(args.title)
+        .setMessage(args.message)
+        .setNegativeButton(R.string.template_retry_dialog_button_negative) { dialog, _ ->
+            dialog.cancel()
+        }
+        .setPositiveButton(R.string.template_retry_dialog_button_positive) { _, _ ->
+            setResult(true)
+        }
+        .create()
+
+
+    override fun onCancel(dialog: DialogInterface) {
+        setResult(false)
+    }
+
+
+    private fun setResult(shouldRetry: Boolean) {
+        findNavController().previousBackStackEntry
+            ?.savedStateHandle
+            ?.set(KEY_RESULT, shouldRetry)
+    }
+
+
+    companion object {
+
+        const val KEY_RESULT = "KEY_RESULT"
+    }
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -5,6 +5,26 @@
     android:id="@+id/nav_graph"
     app:startDestination="@id/oneFragment">
 
+    <!-- リトライダイアログの表示 -->
+    <action
+        android:id="@+id/nav_show_retry_dialog"
+        app:destination="@id/template_retry_dialog" />
+
+
+    <dialog
+        android:id="@+id/template_retry_dialog"
+        android:name="jp.co.yumemi.android.code_check.templates.RetryDialogFragment">
+
+        <argument
+            android:name="title"
+            app:argType="string" />
+
+        <argument
+            android:name="message"
+            app:argType="string" />
+    </dialog>
+
+
     <fragment
         android:id="@+id/oneFragment"
         android:name="jp.co.yumemi.android.code_check.OneFragment"

--- a/app/src/main/res/navigation/nav_graph_entry_point.xml
+++ b/app/src/main/res/navigation/nav_graph_entry_point.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_entry_point"
-    app:startDestination="@id/oneFragment">
+    app:startDestination="@id/template_retry_dialog">
+
+
+    <!-- リトライダイアログの表示 -->
+    <action
+        android:id="@+id/nav_show_retry_dialog"
+        app:destination="@id/template_retry_dialog" />
+
+
+    <dialog
+        android:id="@+id/template_retry_dialog"
+        android:name="jp.co.yumemi.android.code_check.templates.RetryDialogFragment">
+
+        <argument
+            android:name="title"
+            android:defaultValue="通信エラー"
+            app:argType="string" />
+
+        <argument
+            android:name="message"
+            android:defaultValue="通信状態が悪いようです。しばらく時間を置いてから再度お試しください。"
+            app:argType="string" />
+    </dialog>
+
 
     <!-- TODO: 画面の差し替え -->
-    <fragment
-        android:id="@+id/oneFragment"
-        android:name="jp.co.yumemi.android.code_check.OneFragment"
-        tools:layout="@layout/fragment_one" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_entry_point.xml
+++ b/app/src/main/res/navigation/nav_graph_entry_point.xml
@@ -2,30 +2,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nav_graph_entry_point"
-    app:startDestination="@id/template_retry_dialog">
-
-
-    <!-- リトライダイアログの表示 -->
-    <action
-        android:id="@+id/nav_show_retry_dialog"
-        app:destination="@id/template_retry_dialog" />
-
-
-    <dialog
-        android:id="@+id/template_retry_dialog"
-        android:name="jp.co.yumemi.android.code_check.templates.RetryDialogFragment">
-
-        <argument
-            android:name="title"
-            android:defaultValue="通信エラー"
-            app:argType="string" />
-
-        <argument
-            android:name="message"
-            android:defaultValue="通信状態が悪いようです。しばらく時間を置いてから再度お試しください。"
-            app:argType="string" />
-    </dialog>
-
+    app:startDestination="@id/oneFragment">
 
     <!-- TODO: 画面の差し替え -->
 </navigation>

--- a/app/src/main/res/values/app.xml
+++ b/app/src/main/res/values/app.xml
@@ -14,6 +14,13 @@
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimary</item>
     </style>
 
+    <!-- ダイアログテーマ -->
+    <style name="ThemeOverlay.App.Dialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="colorSurface">@color/app_base</item>
+        <item name="colorOnSurface">@color/app_base_on</item>
+        <item name="colorPrimary">@color/app_accent</item>
+    </style>
+
 
     <!-- 配色ルール関連 -->
     <color name="app_main">#24292F</color>

--- a/app/src/main/res/values/template_retry_dialog.xml
+++ b/app/src/main/res/values/template_retry_dialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="template_retry_dialog_button_negative">キャンセル</string>
+    <string name="template_retry_dialog_button_positive">リトライ</string>
+</resources>

--- a/variables.gradle
+++ b/variables.gradle
@@ -22,7 +22,7 @@ ext {
     def versionOkHttp = '4.10.0'
     def versionRetrofit = '2.9.0'
     libraries = [
-            androidx  : [
+            androidx   : [
                     annotation      : 'androidx.annotation:annotation:1.2.0',
                     appcompat       : 'androidx.appcompat:appcompat:1.3.1',
                     constraintlayout: 'androidx.constraintlayout:constraintlayout:2.1.1',
@@ -43,42 +43,44 @@ ext {
                     recyclerview    : 'androidx.recyclerview:recyclerview:1.2.1',
                     uiautomator     : 'androidx.test.uiautomator:uiautomator:2.2.0',
             ],
-            coil      : 'io.coil-kt:coil:1.3.2',
-            coroutines: [
+            autoservice: 'com.google.auto.service:auto-service:1.1.1',
+            coil       : 'io.coil-kt:coil:1.3.2',
+            coroutines : [
                     bom    : 'org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.1',
                     android: 'org.jetbrains.kotlinx:kotlinx-coroutines-android',
                     core   : 'org.jetbrains.kotlinx:kotlinx-coroutines-core',
                     test   : 'org.jetbrains.kotlinx:kotlinx-coroutines-test',
             ],
-            firebase  : [
+            firebase   : [
                     bom        : 'com.google.firebase:firebase-bom:32.5.0',
                     crashlytics: 'com.google.firebase:firebase-crashlytics',
             ],
-            hyperion  : [
+            hyperion   : [
                     attr       : "com.willowtreeapps.hyperion:hyperion-attr:$versionHyperion",
                     core       : "com.willowtreeapps.hyperion:hyperion-core:$versionHyperion",
                     measurement: "com.willowtreeapps.hyperion:hyperion-measurement:$versionHyperion",
+                    plugin     : "com.willowtreeapps.hyperion:hyperion-plugin:$versionHyperion",
                     timber     : "com.willowtreeapps.hyperion:hyperion-timber:$versionHyperion",
             ],
-            junit     : 'junit:junit:4.13.2',
-            ktor      : 'io.ktor:ktor-client-android:1.6.4',
-            leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.12',
-            material  : 'com.google.android.material:material:1.4.0',
-            mockK     : "io.mockk:mockk:${versionMockK}",
-            moshi     : [
+            junit      : 'junit:junit:4.13.2',
+            ktor       : 'io.ktor:ktor-client-android:1.6.4',
+            leakCanary : 'com.squareup.leakcanary:leakcanary-android:2.12',
+            material   : 'com.google.android.material:material:1.4.0',
+            mockK      : "io.mockk:mockk:${versionMockK}",
+            moshi      : [
                     adapters: "com.squareup.moshi:moshi-adapters:$versionMoshi",
                     moshi   : "com.squareup.moshi:moshi-kotlin:$versionMoshi",
             ],
-            okhttp    : [
-                    bom   : "com.squareup.okhttp3:okhttp-bom:$versionOkHttp",
+            okhttp     : [
+                    bom    : "com.squareup.okhttp3:okhttp-bom:$versionOkHttp",
                     logging: "com.squareup.okhttp3:logging-interceptor",
-                    mock  : "com.squareup.okhttp3:mockwebserver",
-                    okhttp: "com.squareup.okhttp3:okhttp",
+                    mock   : "com.squareup.okhttp3:mockwebserver",
+                    okhttp : "com.squareup.okhttp3:okhttp",
             ],
-            retrofit  : [
+            retrofit   : [
                     converter: "com.squareup.retrofit2:converter-moshi:$versionRetrofit",
                     retrofit : "com.squareup.retrofit2:retrofit:$versionRetrofit",
             ],
-            timber    : 'com.jakewharton.timber:timber:5.0.1',
+            timber     : 'com.jakewharton.timber:timber:5.0.1',
     ]
 }


### PR DESCRIPTION
* [x] 新規追加

## 概要
下記を追加しました。

* #50 リトライダイアログのUI
* #90 debug ビルドで手軽にリトライダイアログを表示できる機構
    * 実装の都合で、どうしても必要になったため



## 変更点
### 追加
* リトライダイアログ
*  debug ビルドで手軽にリトライダイアログを表示できる機構

### 修正
* navigation の調整



## 確認事項
※本格的な確認は、各画面に組み込んだ際に依頼したいです。

* [ ] 実装面で不備が無さそう



## 備考
* 特になし
