### PR TITLE
#85 詳細画面の追加

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryViewData.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryViewData.kt
@@ -6,6 +6,7 @@ import androidx.annotation.IntRange
  * リポジトリの表示データ
  *
  * @property forkCount フォーク数
+ * @property imageText 表示画像の説明文言
  * @property imageUrl 表示画像のURL
  * @property issueCount 未解決のIssue 数
  * @property language プログラミング言語
@@ -15,6 +16,7 @@ import androidx.annotation.IntRange
  */
 data class RepositoryViewData(
     @IntRange(from = 0) val forkCount: Int,
+    val imageText: String,
     val imageUrl: String?,
     @IntRange(from = 0) val issueCount: Int,
     val language: String?,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailFragment.kt
@@ -1,0 +1,64 @@
+package jp.co.yumemi.android.code_check.pages.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.navigation.navGraphViewModels
+import coil.load
+import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.databinding.PageDetailBinding
+
+/**
+ * 詳細画面
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ * * [DetailViewModel] に表示データを設定している
+ */
+class DetailFragment : Fragment(R.layout.page_detail) {
+
+    private var binding: PageDetailBinding? = null
+
+    private val viewModel by navGraphViewModels<DetailViewModel>(R.id.nav_graph_entry_point)
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val data = viewModel.data ?: throw IllegalArgumentException("表示データを設定してください")
+
+        binding = PageDetailBinding.bind(view).apply {
+            pageDetailHeader.setTitle(R.string.page_detail_title)
+
+            pageDetailImage.load(data.imageUrl)
+            pageDetailImage.contentDescription = data.imageText
+
+            pageDetailLabelTitle.text = data.title
+
+            pageDetailLabelForks.text = getString(
+                R.string.page_detail_label_forks,
+                data.forkCount,
+            )
+            pageDetailLabelIssues.text = getString(
+                R.string.page_detail_label_issues,
+                data.issueCount,
+            )
+            pageDetailLabelLanguage.text = getString(
+                R.string.page_detail_label_language,
+                data.language,
+            )
+            pageDetailLabelStars.text = getString(
+                R.string.page_detail_label_stars,
+                data.starCount,
+            )
+            pageDetailLabelWatchers.text = getString(
+                R.string.page_detail_label_watchers,
+                data.watcherCount,
+            )
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailFragment.kt
@@ -3,6 +3,7 @@ package jp.co.yumemi.android.code_check.pages.detail
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
 import coil.load
 import jp.co.yumemi.android.code_check.R
@@ -27,7 +28,7 @@ class DetailFragment : Fragment(R.layout.page_detail) {
         val data = viewModel.data ?: throw IllegalArgumentException("表示データを設定してください")
 
         binding = PageDetailBinding.bind(view).apply {
-            pageDetailHeader.setTitle(R.string.page_detail_title)
+            pageDetailHeader.setupWith(findNavController())
 
             pageDetailImage.load(data.imageUrl)
             pageDetailImage.contentDescription = data.imageText

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/detail/DetailViewModel.kt
@@ -1,0 +1,15 @@
+package jp.co.yumemi.android.code_check.pages.detail
+
+import androidx.lifecycle.ViewModel
+import jp.co.yumemi.android.code_check.RepositoryViewData
+
+/**
+ * 詳細画面のViewModel
+ */
+class DetailViewModel : ViewModel() {
+
+    /**
+     * 表示データ
+     */
+    var data: RepositoryViewData? = null
+}

--- a/app/src/main/res/layout/page_detail.xml
+++ b/app/src/main/res/layout/page_detail.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/app_base"
+    android:orientation="vertical"
+    tools:context=".EntryPointActivity">
+
+    <jp.co.yumemi.android.code_check.molecules.SimpleToolbar
+        android:id="@+id/page_detail_header"
+        android:layout_width="match_parent"
+        android:layout_height="?actionBarSize" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/page_detail_image"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:adjustViewBounds="true"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="240dp"
+                tools:contentDescription="@tools:sample/full_names"
+                tools:src="@tools:sample/avatars" />
+
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textColor="@color/app_base_on"
+                android:textSize="18sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/page_detail_image"
+                tools:text="@tools:sample/full_names" />
+
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_language"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:textColor="@color/app_base_on"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toStartOf="@id/page_detail_label_stars"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintHorizontal_weight="1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/page_detail_label_title"
+                tools:text="@string/page_detail_label_language" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_stars"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:textAlignment="textEnd"
+                android:textColor="@color/app_base_on"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_weight="1"
+                app:layout_constraintStart_toEndOf="@id/page_detail_label_language"
+                app:layout_constraintTop_toTopOf="@id/page_detail_label_language"
+                tools:text="@string/page_detail_label_stars" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_watchers"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAlignment="textEnd"
+                android:textColor="@color/app_base_on"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="@id/page_detail_label_stars"
+                app:layout_constraintStart_toStartOf="@id/page_detail_label_stars"
+                app:layout_constraintTop_toBottomOf="@id/page_detail_label_stars"
+                tools:text="@string/page_detail_label_watchers" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_forks"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAlignment="textEnd"
+                android:textColor="@color/app_base_on"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="@id/page_detail_label_stars"
+                app:layout_constraintStart_toStartOf="@id/page_detail_label_stars"
+                app:layout_constraintTop_toBottomOf="@id/page_detail_label_watchers"
+                tools:text="@string/page_detail_label_forks" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/page_detail_label_issues"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="8dp"
+                android:textAlignment="textEnd"
+                android:textColor="@color/app_base_on"
+                android:textSize="12sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/page_detail_label_stars"
+                app:layout_constraintStart_toStartOf="@id/page_detail_label_stars"
+                app:layout_constraintTop_toBottomOf="@id/page_detail_label_forks"
+                tools:text="@string/page_detail_label_issues" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/navigation/nav_graph_entry_point.xml
+++ b/app/src/main/res/navigation/nav_graph_entry_point.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_entry_point"
     app:startDestination="@id/oneFragment">
 
-    <!-- TODO: 画面の差し替え -->
+    <fragment
+        android:id="@+id/page_detail"
+        android:name="jp.co.yumemi.android.code_check.pages.detail.DetailFragment"
+        android:label="@string/page_detail_title"
+        tools:layout="@layout/page_detail" />
 </navigation>

--- a/app/src/main/res/values/page_detail.xml
+++ b/app/src/main/res/values/page_detail.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="page_detail_label_forks">%s forks</string>
+    <string name="page_detail_label_issues">%s open issues</string>
+    <string name="page_detail_label_language">Written in %s</string>
+    <string name="page_detail_label_stars">%s stars</string>
+    <string name="page_detail_label_watchers">%s watchers</string>
+</resources>

--- a/app/src/main/res/values/page_detail.xml
+++ b/app/src/main/res/values/page_detail.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="page_detail_label_forks">%s forks</string>
-    <string name="page_detail_label_issues">%s open issues</string>
+    <string name="page_detail_label_forks">%d forks</string>
+    <string name="page_detail_label_issues">%d open issues</string>
     <string name="page_detail_label_language">Written in %s</string>
-    <string name="page_detail_label_stars">%s stars</string>
-    <string name="page_detail_label_watchers">%s watchers</string>
+    <string name="page_detail_label_stars">%d stars</string>
+    <string name="page_detail_label_watchers">%d watchers</string>
+
+    <string name="page_detail_title">詳細画面</string>
 </resources>


### PR DESCRIPTION
* [x] 新規追加

## 概要
`TwoFragment` をリファインした詳細画面を追加しました。



## 変更点
### 追加
* 詳細画面の追加

### 修正
* リポジトリの表示データに画像の説明文言を追加
    * 読み上げテキストが無いため
* ナビゲーション設定の追加



## 確認事項
<details>
<summary>事前準備</summary>

1. AndroidManifest で起動Activity を`EntryPointActivity` に変更する
1. nav_graph_entry_point の`app:startDestination` に今回追加した詳細画面に変更する
1. `DetailViewModel.data` に適当な初期値を設定する
</details>

お手数ですが、上記の事前準備を行ってから、下記をお試しくださいませ。

* [ ] 画面が表示される
* [ ] ダークモードでも表示が見える
* [ ] 画面回転させて、領域が狭くなっても、スクロールすることで確認できる



## 備考
* 特になし
