### PR TITLE
#96 結果通知ダイアログの追加

### DIFF
--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/ShowNotifyDialogHyperionPlugin.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/ShowNotifyDialogHyperionPlugin.kt
@@ -1,0 +1,46 @@
+package jp.co.yumemi.android.code_check
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.navigation.findNavController
+import com.google.auto.service.AutoService
+import com.willowtreeapps.hyperion.plugin.v1.Plugin
+import com.willowtreeapps.hyperion.plugin.v1.PluginModule
+import jp.co.yumemi.android.code_check.molecules.HyperionMenuItemView
+import jp.co.yumemi.android.code_check.templates.NotifyDialogFragmentDirections
+
+/**
+ * 結果通知ダイアログを表示するHyperion Plugin
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ */
+@AutoService(Plugin::class)
+class ShowNotifyDialogHyperionPlugin : Plugin() {
+
+    override fun createPluginModule() = object : PluginModule() {
+
+        override fun createPluginView(
+            layoutInflater: LayoutInflater,
+            parent: ViewGroup,
+        ) = HyperionMenuItemView(parent.context).apply {
+            setName(name)
+            setOnClickListener {
+                try {
+                    val direction = NotifyDialogFragmentDirections.navShowNotifyDialog(
+                        title = "タイトル from Hyperion",
+                        message = "メッセージ from Hyperion",
+                    )
+                    extension.activity
+                        .findNavController(R.id.nav_host_fragment)
+                        .navigate(direction)
+                } catch (e: Exception) {
+                    Toast.makeText(parent.context, "表示できません", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
+        override fun getName() = R.string.hyperion_show_notify_dialog_title
+    }
+}

--- a/app/src/debug/res/values/hyperion.xml
+++ b/app/src/debug/res/values/hyperion.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <string name="hyperion_show_notify_dialog_title">結果通知ダイアログの表示</string>
     <string name="hyperion_show_retry_dialog_title">リトライダイアログの表示</string>
 </resources>

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/NotifyDialogFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/templates/NotifyDialogFragment.kt
@@ -1,0 +1,32 @@
+package jp.co.yumemi.android.code_check.templates
+
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import jp.co.yumemi.android.code_check.R
+
+/**
+ * 結果を通知するダイアログ
+ *
+ * ## 使用条件
+ * * Jetpack Navigation コンポーネントを利用している
+ *
+ * ## 注意事項
+ * * ダイアログ外に黒透過の背景が無いなどがあれば、まずはOS 標準のダイアログと見比べてください
+ *     * OS 標準のダイアログを表示するには、アプリアンインストールを試すのが手軽です
+ *     * エミュレーターのバグで、上手く表示できない事例があるようなので、色々な端末で見比べてください
+ */
+class NotifyDialogFragment : DialogFragment() {
+
+    private val args by navArgs<NotifyDialogFragmentArgs>()
+
+
+    override fun onCreateDialog(
+        savedInstanceState: Bundle?,
+    ) = MaterialAlertDialogBuilder(requireContext(), R.style.ThemeOverlay_App_Dialog)
+        .setTitle(args.title)
+        .setMessage(args.message)
+        .setPositiveButton(R.string.template_notify_dialog_button_positive, null)
+        .create()
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -5,11 +5,29 @@
     android:id="@+id/nav_graph"
     app:startDestination="@id/oneFragment">
 
+    <!-- 結果通知ダイアログの表示 -->
+    <action
+        android:id="@+id/nav_show_notify_dialog"
+        app:destination="@id/template_notify_dialog" />
+
     <!-- リトライダイアログの表示 -->
     <action
         android:id="@+id/nav_show_retry_dialog"
         app:destination="@id/template_retry_dialog" />
 
+
+    <dialog
+        android:id="@+id/template_notify_dialog"
+        android:name="jp.co.yumemi.android.code_check.templates.NotifyDialogFragment">
+
+        <argument
+            android:name="title"
+            app:argType="string" />
+
+        <argument
+            android:name="message"
+            app:argType="string" />
+    </dialog>
 
     <dialog
         android:id="@+id/template_retry_dialog"

--- a/app/src/main/res/values/template_notify_dialog.xml
+++ b/app/src/main/res/values/template_notify_dialog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="template_notify_dialog_button_positive">OK</string>
+</resources>


### PR DESCRIPTION
* [x] 新規追加

## 概要
結果をただ通知するだけのダイアログを追加しました。



## 変更点
### 追加
* 結果通知ダイアログ
* debug ビルドで手軽に結果通知ダイアログを表示できる機構

### 修正
* navigation の調整



## 確認事項
debug ビルドで、Hyperion プラグイン経由で挙動をお試しくださいませ。

* [ ] デザインに沿った色になっている
* [ ] ダークモードでも意図した色になっている
* [ ] ボタン or 領域外をタップすると、ダイアログが閉じる



## 備考
* 特になし
