### PR TITLE
#92 Android 14 以上でHyperion を無効化する変更

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -10,7 +10,7 @@
 --- | :---: | :---: | ---
 Firebase Crashlytics | - | 利用可能 |  |
 google-services.json | - | 必須 |  |
-[Hyperion] | 利用可能 | - | アプリ起動後に、通知権限を許可した状態でOS 通知欄をタップするか、端末を振るとメニューが出てきます
+[Hyperion] | 利用可能<br />(※Android 13 以下) | - | アプリ起動後に、通知権限を許可した状態でOS 通知欄をタップするか、端末を振るとメニューが出てきます
 [LeakCanary](https://square.github.io/leakcanary/) | 利用可能 | - | アプリ起動後にメモリリークが起きると通知されます
 OkHttp の通信ログ | 利用可能 | - | アプリ起動後にAndroid Studio の"Logcat" ウィンドウを確認してください
 StrictMode | 適用済み | - | 設定内容は[DebugApplication](./src/debug/kotlin/jp.co.yumemi.android.code_check/DebugApplication.kt) を参照してください

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/DebugApplication.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/DebugApplication.kt
@@ -1,7 +1,9 @@
 package jp.co.yumemi.android.code_check
 
+import android.os.Build
 import android.os.StrictMode
 import androidx.fragment.app.strictmode.FragmentStrictMode
+import com.willowtreeapps.hyperion.core.Hyperion
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import timber.log.Timber
@@ -53,5 +55,11 @@ class DebugApplication : MainApplication() {
             .build()
             .also { FragmentStrictMode.defaultPolicy = it }
         // endregion
+
+
+        // TODO: Android 14 以降でHyperion が使えるようになったら、記述を削除する
+        if (Build.VERSION_CODES.UPSIDE_DOWN_CAKE <= Build.VERSION.SDK_INT) {
+            Hyperion.disable()
+        }
     }
 }


### PR DESCRIPTION
* [x] 既存改良

## 概要
Android 14 以上の端末で、debug ビルドを試そうとすると、
Hyperion 内部実装が引っ掛かって、アプリがクラッシュします。

ライブラリのアップデートを待つしかなさそうなので、
暫定処置としてAndroid 14 以上ではHyperion を無効化することにしました。



## 変更点
### 修正
* Android 14 以上でHyperion を無効化する設定の追加
* ドキュメントの更新



## 確認事項
* [ ] Android 14 未満でアプリ起動すると、クラッシュせずにHyperion が使える
* [ ] Android 14 でアプリ起動すると、クラッシュしないが、Hyperion は使えない



## 備考
* [Conditional Startup](https://github.com/willowtreeapps/Hyperion-Android#conditional-startup)
