### PR TITLE
#104 Hyperion メニューアイコンをAndroid 6 以下は非表示にする

### DIFF
--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/molecules/HyperionMenuItemView.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.code_check.molecules
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.os.Build
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
@@ -81,7 +82,9 @@ class HyperionMenuItemView @JvmOverloads constructor(
             layoutParams = LayoutParams(size, size).apply {
                 setMargins(0, 0, spaceH, 0)
             }
-            setImageResource(R.drawable.ic_launcher_foreground)
+            if (Build.VERSION_CODES.N <= Build.VERSION.SDK_INT) {
+                setImageResource(R.drawable.ic_launcher_foreground)
+            }
             ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(colorSelector))
         }
 


### PR DESCRIPTION
* [x] 既存改良
* [x] 不具合修正

## 概要
ic_launcher_foreground.xml はAndroid 7 以降でしか使えないため、アプリがクラッシュしていました。

他のアイコンに差し替えることを検討しましたが、表示がいまいちだったため、Android 6 以下では非表示にするようにしました。

あくまで開発支援機能なので、アイコンが無くても問題がないと判断しました。



## 変更点
### 修正
* OS バージョンによってアイコンを設定するように修正



## 確認事項
* [ ] Android 6 でアプリ起動でき、Hyperion メニューにアイコンが無い
* [ ] Android 7 以上でアプリ起動でき、Hyperion メニューにアイコンがある



## 備考
* 特になし