### PR TITLE
Issue #98 の実装漏れの追加

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,20 +1,27 @@
-# https://developer.android.com/guide/navigation/use-graph/pass-data#proguard_considerations
--keepnames class * extends android.os.Parcelable
-
-# Firabase Crashlytics
+###
+### Firabase Crashlytics
+###
 -keepattributes SourceFile,LineNumberTable        # Keep file names and line numbers.
 -keep public class * extends java.lang.Exception  # Optional: Keep custom exceptions.
 
-# Log
-# https://www.jssec.org/dl/android_securecoding_20220829/4_using_technology_in_a_safe_way.html#system-out-err
+
+
+###
+### Log
+### https://www.jssec.org/dl/android_securecoding_20220829/4_using_technology_in_a_safe_way.html#system-out-err
+###
 -assumenosideeffects class android.util.Log {
     public static int d(...);
     public static int i(...);
     public static int v(...);
 }
 
-# OkHttp
-# https://square.github.io/okhttp/features/r8_proguard/
+
+
+###
+### OkHttp
+### https://square.github.io/okhttp/features/r8_proguard/
+###
 # JSR 305 annotations are for embedding nullability information.
 -dontwarn javax.annotation.**
 

--- a/app/src/debug/res/values/app.xml
+++ b/app/src/debug/res/values/app.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- アプリ名 -->
     <string name="app_name">[D]Android Engineer CodeCheck</string>
 </resources>

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
@@ -87,8 +87,8 @@ class SearchFragment : Fragment(R.layout.page_search) {
                         result?.onSuccess {
                             binding?.pageSearchList?.adapter?.submitList(it)
                             binding?.pageSearchListEmpty?.isVisible = it.isEmpty()
-                        }?.onFailure {
-                            when (it) {
+                        }?.onFailure { e ->
+                            when (e) {
                                 is IllegalArgumentException,
                                 is IndexOutOfBoundsException -> NavGraphEntryPointDirections.navShowNotifyDialog(
                                     title = getString(R.string.page_search_error_title_invalid),
@@ -101,7 +101,7 @@ class SearchFragment : Fragment(R.layout.page_search) {
                                 )
 
                                 else -> {
-                                    Timber.e(it)
+                                    Timber.e(e)
                                     NavGraphEntryPointDirections.navShowNotifyDialog(
                                         title = getString(R.string.page_search_error_title_http),
                                         message = getString(R.string.page_search_error_message_http),

--- a/app/src/main/res/values/app.xml
+++ b/app/src/main/res/values/app.xml
@@ -32,4 +32,8 @@
 
     <!-- 透過色 -->
     <color name="app_transparent_shadow">#4D000000</color>
+
+
+    <!-- アプリ名 -->
+    <string name="app_name">Android Engineer CodeCheck</string>
 </resources>

--- a/github_web_api/README.md
+++ b/github_web_api/README.md
@@ -81,7 +81,7 @@ GitHub REST API とHTTP 通信をするモジュール。
         * [OkHttp](https://github.com/square/okhttp)
 * モジュール内部利用
     * [Moshi Adapters](https://github.com/square/moshi/tree/master/moshi-adapters) ([Maven Central](https://mvnrepository.com/artifact/com.squareup.moshi/moshi-adapters))
-    * [Moshi Kotlin](https://github.com/square/moshi#kotlin) ([Maven Central](https://mvnrepository.com/artifact/com.squareup.moshi/moshi-kotlin))
+    * [Moshi Codegen](https://github.com/square/moshi#codegen) ([Maven Central](https://mvnrepository.com/artifact/com.squareup.moshi/moshi-kotlin-codegen))
     * [Retrofit](https://github.com/square/retrofit) ([Maven Central](https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit))
     * [Retrofit Converters](https://github.com/square/retrofit/tree/master/retrofit-converters)
         * Converter: Moshi ([Maven Central](https://mvnrepository.com/artifact/com.squareup.retrofit2/converter-moshi))

--- a/github_web_api/build.gradle
+++ b/github_web_api/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     // Moshi
     implementation "${libraries.moshi.adapters}"
     kapt "${libraries.moshi.codegen}"
-    implementation "${libraries.moshi.moshi}"
 
     // OkHttp
     implementation platform("${libraries.okhttp.bom}")

--- a/github_web_api/build.gradle
+++ b/github_web_api/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 plugins {
     id 'java-library'
     id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.kapt'
 }
 
 java {
@@ -25,6 +26,7 @@ dependencies {
 
     // Moshi
     implementation "${libraries.moshi.adapters}"
+    kapt "${libraries.moshi.codegen}"
     implementation "${libraries.moshi.moshi}"
 
     // OkHttp

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/GitHubWebApi.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/GitHubWebApi.kt
@@ -3,7 +3,6 @@ package io.github.tshion.android.codecheck.github.webapi
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.tshion.android.codecheck.github.webapi.entities.GitHubErrorResponse
 import io.github.tshion.android.codecheck.github.webapi.utils.GitHubInterceptor
 import io.github.tshion.android.codecheck.github.webapi.utils.OffsetDateTimeAdapter
@@ -47,7 +46,6 @@ public class GitHubWebApi internal constructor(
 
     init {
         val moshi = Moshi.Builder()
-            .addLast(KotlinJsonAdapterFactory())
             .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
             .add(OffsetDateTimeAdapter())
             .build()

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GetSearchRepositoriesResponse.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GetSearchRepositoriesResponse.kt
@@ -1,10 +1,13 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * @param total_count
  * @param incomplete_results
  * @param items
  */
+@JsonClass(generateAdapter = true)
 public data class GetSearchRepositoriesResponse(
     val total_count: Int,
     val incomplete_results: Boolean,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GitHubErrorItem.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GitHubErrorItem.kt
@@ -1,5 +1,8 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 public data class GitHubErrorItem(
     val resource: String,
     val field: String,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GitHubErrorResponse.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/GitHubErrorResponse.kt
@@ -1,10 +1,13 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * GitHub REST API のエラーレスポンス
  *
  * ※[参考文献](https://docs.github.com/ja/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#client-errors)
  */
+@JsonClass(generateAdapter = true)
 public data class GitHubErrorResponse(
     val message: String,
     val errors: List<GitHubErrorItem>? = null,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/Matches.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/Matches.kt
@@ -1,5 +1,8 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 public data class Matches(
     val text: String? = null,
     val indices: List<Int>? = null,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/NullableLicenseSimple.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/NullableLicenseSimple.kt
@@ -1,5 +1,7 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * License Simple
  *
@@ -10,6 +12,7 @@ package io.github.tshion.android.codecheck.github.webapi.entities
  * @param node_id
  * @param html_url
  */
+@JsonClass(generateAdapter = true)
 public data class NullableLicenseSimple(
     val key: String,
     val name: String,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/NullableSimpleUser.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/NullableSimpleUser.kt
@@ -1,5 +1,7 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * A GitHub user.
  *
@@ -25,6 +27,7 @@ package io.github.tshion.android.codecheck.github.webapi.entities
  * @param site_admin
  * @param starred_at
  */
+@JsonClass(generateAdapter = true)
 public data class NullableSimpleUser(
     val name: String? = null,
     val email: String? = null,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/Permissions.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/Permissions.kt
@@ -1,5 +1,7 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * @param admin
  * @param maintain
@@ -7,6 +9,7 @@ package io.github.tshion.android.codecheck.github.webapi.entities
  * @param triage
  * @param pull
  */
+@JsonClass(generateAdapter = true)
 public data class Permissions(
     val admin: Boolean,
     val maintain: Boolean? = null,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/RepoSearchResultItem.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/RepoSearchResultItem.kt
@@ -1,5 +1,7 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
 /**
  * Repo Search Result Item
  *
@@ -93,6 +95,7 @@ package io.github.tshion.android.codecheck.github.webapi.entities
  * @param is_template
  * @param web_commit_signoff_required
  */
+@JsonClass(generateAdapter = true)
 public data class RepoSearchResultItem(
     val id: Int,
     val node_id: String,
@@ -175,7 +178,7 @@ public data class RepoSearchResultItem(
     val visibility: String? = null,
     val license: NullableLicenseSimple?,
     val permissions: Permissions? = null,
-    val textMatches: List<SearchResultTextMatches>? = null,
+    val text_matches: List<SearchResultTextMatches>? = null,
     val temp_clone_token: String? = null,
     val allow_merge_commit: Boolean? = null,
     val allow_squash_merge: Boolean? = null,

--- a/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/SearchResultTextMatches.kt
+++ b/github_web_api/src/main/java/io/github/tshion/android/codecheck/github/webapi/entities/SearchResultTextMatches.kt
@@ -1,5 +1,8 @@
 package io.github.tshion.android.codecheck.github.webapi.entities
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 public data class SearchResultTextMatches(
     val objectUrl: String? = null,
     val objectType: String? = null,

--- a/github_web_api/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/github_web_api/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -1,0 +1,48 @@
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep inherited services.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# With R8 full mode generic signatures are stripped for classes that are not kept.
+-keep,allowobfuscation,allowshrinking class retrofit2.Response

--- a/variables.gradle
+++ b/variables.gradle
@@ -70,7 +70,6 @@ ext {
             moshi      : [
                     adapters: "com.squareup.moshi:moshi-adapters:$versionMoshi",
                     codegen : "com.squareup.moshi:moshi-kotlin-codegen:$versionMoshi",
-                    moshi   : "com.squareup.moshi:moshi-kotlin:$versionMoshi",
             ],
             okhttp     : [
                     bom    : "com.squareup.okhttp3:okhttp-bom:$versionOkHttp",

--- a/variables.gradle
+++ b/variables.gradle
@@ -69,6 +69,7 @@ ext {
             mockK      : "io.mockk:mockk:${versionMockK}",
             moshi      : [
                     adapters: "com.squareup.moshi:moshi-adapters:$versionMoshi",
+                    codegen : "com.squareup.moshi:moshi-kotlin-codegen:$versionMoshi",
                     moshi   : "com.squareup.moshi:moshi-kotlin:$versionMoshi",
             ],
             okhttp     : [


### PR DESCRIPTION
* [x] 既存改良
* [x] 不具合修正

## 概要
Issue #98 に対応したPR #110 にいくつか実装漏れがありました。
なので本PR でその対応を行いました。



## 変更点
### 追加
* main で定義が漏れていたアプリ名のリソースを追加

### 修正
* ProGuard の調整
    * Java / Kotlin モジュールのProGuard 設定ファイルを追加
    * JSON のキー名のタイプ修正
    * moshi をReflection からCodegen へ変更
        * minify した際に何故か名前解決できずクラッシュしたため
* ネストされたスコープ関数の`it` の内容を明示するように修正



## 確認事項
* [ ] release ビルド出来る
* [ ] アプリ実行して、特に問題が無い



## 備考
### Java / Kotlin モジュールのProGuard 設定の参考文献
* https://github.com/square/retrofit/pull/2787#issuecomment-396401208
* [R8/Proguard: JarファイルからProGuard設定ファイルを読み込んでくれるようになりました  - stsnブログ ](https://satoshun.github.io/2019/01/r8-proguard-metainf/)
