### PR TITLE
XML タグの並び替えルールを無効化

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -221,6 +221,7 @@
               </match>
             </rule>
           </section>
+          <!--
           <section>
             <rule>
               <match>
@@ -232,6 +233,7 @@
               <order>BY_NAME</order>
             </rule>
           </section>
+          -->
           <section>
             <rule>
               <match>
@@ -285,6 +287,7 @@
               <order>BY_NAME</order>
             </rule>
           </section>
+          <!--
           <section>
             <rule>
               <match>
@@ -296,6 +299,8 @@
               <order>BY_NAME</order>
             </rule>
           </section>
+          -->
+          <!--
           <section>
             <rule>
               <match>
@@ -307,6 +312,7 @@
               <order>BY_NAME</order>
             </rule>
           </section>
+          -->
         </rules>
       </arrangement>
     </codeStyleSettings>


### PR DESCRIPTION
* [x] 既存改良

## 概要
レイアウトXML でコードフォーマットを行った際、
タグ名のa-z 順で並び替えられてしまい、
View 構造が崩れていました。

なので整形ルールを調整してみました。



## 変更点
### 修正
* XML の整形ルールを調整



## 確認事項
* [ ] XML ファイルでコード整形を行っても、タグ名で並び変わらない



## 備考
* 特になし
