### PR TITLE
#128 ArchUnit を使ってapp モジュール内の依存関係が意図したものになっているかの検証追加

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -89,6 +89,7 @@ Git 管理から外しているため、試す際は追加でセットアップ�
             * espresso-core ([Maven Google](https://mvnrepository.com/artifact/androidx.test.espresso/espresso-core))
             * junit-ktx ([Maven Google](https://mvnrepository.com/artifact/androidx.test.ext/junit-ktx))
         * [uiautomator](https://developer.android.com/jetpack/androidx/releases/test-uiautomator) ([Maven Google](https://mvnrepository.com/artifact/androidx.test.uiautomator/uiautomator))
+    * [ArchUnit](https://github.com/TNG/ArchUnit) ([Maven Central](https://mvnrepository.com/artifact/com.tngtech.archunit/archunit-junit4))
     * [JUnit4](https://github.com/junit-team/junit4) ([Maven Central](https://mvnrepository.com/artifact/junit/junit))
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     implementation "${libraries.androidx.recyclerview}"
     androidTestImplementation "${libraries.androidx.uiautomator}"
 
+    // ArchUnit
+    testImplementation "${libraries.archUnit}"
+
     // Auto Service
     kaptDebug "${libraries.autoservice}"
 
@@ -111,6 +114,9 @@ dependencies {
     debugImplementation "${libraries.hyperion.measurement}"
     debugImplementation "${libraries.hyperion.plugin}"
     debugImplementation "${libraries.hyperion.timber}"
+
+    // JUnit
+    testImplementation "${libraries.junit}"
 
     // Kotlin Coroutines
     implementation "${libraries.coroutines.bom}"

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ArchitectureUnitTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ArchitectureUnitTest.kt
@@ -1,0 +1,81 @@
+package jp.co.yumemi.android.code_check
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.junit.ArchUnitRunner
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition
+import org.junit.runner.RunWith
+
+/**
+ * アーキテクチャに沿った実装がされているかを検証するユニットテスト
+ */
+@AnalyzeClasses(packages = ["jp.co.yumemi.android.code_check"])
+@RunWith(ArchUnitRunner::class)
+class ArchitectureUnitTest {
+
+    @ArchTest
+    fun atoms(classes: JavaClasses) {
+        val rules = noClasses().that().resideInAPackage("..atoms..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                "..models..",
+                "..molecules..",
+                "..organisms..",
+                "..pages..",
+                "..templates..",
+            )
+        rules.check(classes)
+    }
+
+    @ArchTest
+    fun molecules(classes: JavaClasses) {
+        val rules = noClasses().that().resideInAPackage("..molecules..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                "..models..",
+                "..organisms..",
+                "..pages..",
+                "..templates..",
+            )
+        rules.check(classes)
+    }
+
+    @ArchTest
+    fun organisms(classes: JavaClasses) {
+        val rules = noClasses().that().resideInAPackage("..organisms..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                "..models..",
+                "..pages..",
+                "..templates..",
+            )
+        rules.check(classes)
+    }
+
+    @ArchTest
+    fun pages(classes: JavaClasses) {
+        val rules = noClasses().that().resideInAPackage("..pages..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                "..models..",
+            )
+        rules.check(classes)
+    }
+
+    @ArchTest
+    fun templates(classes: JavaClasses) {
+        val rules = noClasses().that().resideInAPackage("..templates..")
+            .should().dependOnClassesThat().resideInAnyPackage(
+                "..models..",
+                "..pages..",
+            )
+        rules.check(classes)
+    }
+
+    @ArchTest
+    fun 循環参照していない(classes: JavaClasses) {
+        val rules = SlicesRuleDefinition.slices()
+            .matching("jp.co.yumemi.android.code_check.(*)..")
+            .should()
+            .beFreeOfCycles()
+        rules.check(classes)
+    }
+}

--- a/variables.gradle
+++ b/variables.gradle
@@ -43,6 +43,7 @@ ext {
                     recyclerview    : 'androidx.recyclerview:recyclerview:1.2.1',
                     uiautomator     : 'androidx.test.uiautomator:uiautomator:2.2.0',
             ],
+            archUnit   : 'com.tngtech.archunit:archunit-junit4:1.2.0',
             autoservice: 'com.google.auto.service:auto-service:1.1.1',
             coil       : 'io.coil-kt:coil:1.3.2',
             coroutines : [


### PR DESCRIPTION
* [x] 新規追加

## 概要
[ArchUnit](https://github.com/TNG/ArchUnit) を使うと、意図したクラス関係になっているかの検証が出来るようです。

app モジュールはパッケージが多く、試してみるのにちょうど良さそうなため、
atomic design 関連の依存関係を検証するようにしてみました。



## 変更点
### 追加
* ArchUnit の依存追加
* ユニットテストの追加



## 確認事項
* [ ] 追加したユニットテストが成功する



## 備考
### 参考文献
* [Use Cases - ArchUnit](https://www.archunit.org/use-cases)
* [はじめてのArchUnit #Java - Qiita](https://qiita.com/daisuzz/items/f33b4e02bb3f5fdbc048)
