### PR TITLE
#121 検索画面の結果一覧にページング対応を追加

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -61,6 +61,7 @@ Git 管理から外しているため、試す際は追加でセットアップ�
             * fragment-ktx ([Maven Google](https://mvnrepository.com/artifact/androidx.navigation/navigation-fragment-ktx))
             * ui-ktx ([Maven Google](https://mvnrepository.com/artifact/androidx.navigation/navigation-ui-ktx))
         * [recyclerview](https://developer.android.com/jetpack/androidx/releases/recyclerview) ([Maven Google](https://mvnrepository.com/artifact/androidx.recyclerview/recyclerview))
+        * [paging](https://developer.android.com/jetpack/androidx/releases/paging) ([Maven Google](https://mvnrepository.com/artifact/androidx.paging/paging-runtime))
     * [COIL](https://github.com/coil-kt/coil) ([Maven Central](https://mvnrepository.com/artifact/io.coil-kt/coil))
     * [desugar](https://github.com/google/desugar_jdk_libs) ([Maven Google](https://mvnrepository.com/artifact/com.android.tools/desugar_jdk_libs))
     * Firebase BOM ([Maven Google](https://mvnrepository.com/artifact/com.google.firebase/firebase-bom))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation "${libraries.androidx.lifecycle.viewmodel}"
     implementation "${libraries.androidx.navigation.fragment}"
     implementation "${libraries.androidx.navigation.ui}"
+    implementation "${libraries.androidx.paging}"
     implementation "${libraries.androidx.recyclerview}"
     androidTestImplementation "${libraries.androidx.uiautomator}"
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/GitHubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/GitHubRepository.kt
@@ -50,8 +50,9 @@ class GitHubRepository(
                 return@mapNotNull item
             }
 
+            val count = query.perPage * query.page
             RepositoryResultEntity(
-                hasMore = response.incomplete_results,
+                hasMore = count < response.total_count,
                 items = items,
             )
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/RepositoriesPagingSource.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/RepositoriesPagingSource.kt
@@ -1,22 +1,23 @@
-package jp.co.yumemi.android.code_check.pages.search
+package jp.co.yumemi.android.code_check.models
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import io.github.tshion.android.codecheck.core.SearchUseCase
-import jp.co.yumemi.android.code_check.organisms.repository_list_view.RepositoryListItemViewData
+import io.github.tshion.android.codecheck.core.entities.RepositoryEntity
+import io.github.tshion.android.codecheck.core.entities.RepositoryQueryEntity
 
 /**
- * ページング出来るリポジトリ一覧情報
+ * データ[RepositoryEntity] のページング実装
  */
 class RepositoriesPagingSource private constructor(
     private val keyword: String,
     private val searchUseCase: SearchUseCase,
-) : PagingSource<Int, RepositoryListItemViewData>() {
+) : PagingSource<Int, RepositoryEntity>() {
 
     override fun getRefreshKey(
-        state: PagingState<Int, RepositoryListItemViewData>,
+        state: PagingState<Int, RepositoryEntity>,
     ) = state.anchorPosition?.let {
         val anchorPage = state.closestPageToPosition(it)
         return@let anchorPage?.prevKey?.plus(1)
@@ -29,12 +30,8 @@ class RepositoriesPagingSource private constructor(
         val currentPage = params.key ?: 1
 
         val result = searchUseCase.searchRepositories(keyword, currentPage)
-
-        // TODO: View 都合による変換ロジックの移動
-        val data = result.items.map { RepositoryListItemViewData(it) }
-
         LoadResult.Page(
-            data = data,
+            data = result.items,
             prevKey = null,
             nextKey = (currentPage + 1).takeIf { result.hasMore },
         )
@@ -55,7 +52,7 @@ class RepositoriesPagingSource private constructor(
             keyword: String,
             searchUseCase: SearchUseCase,
         ) = PagingConfig(
-            pageSize = 50, // FIXME: RepositoryQueryEntity の値を利用する
+            pageSize = RepositoryQueryEntity.PER_PAGE,
         ).let {
             Pager(it) { RepositoriesPagingSource(keyword, searchUseCase) }
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/organisms/repository_list_view/RepositoryListViewAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/organisms/repository_list_view/RepositoryListViewAdapter.kt
@@ -4,8 +4,8 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import io.github.tshion.android.codecheck.core.entities.RepositoryEntity
 import jp.co.yumemi.android.code_check.molecules.SimpleListItemView
 
@@ -16,7 +16,7 @@ import jp.co.yumemi.android.code_check.molecules.SimpleListItemView
  */
 class RepositoryListViewAdapter(
     private val onTapListener: (RepositoryEntity) -> Unit,
-) : ListAdapter<RepositoryListItemViewData, SimpleListItemView.ViewHolder>(diffs) {
+) : PagingDataAdapter<RepositoryListItemViewData, SimpleListItemView.ViewHolder>(diffs) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -27,9 +27,15 @@ class RepositoryListViewAdapter(
 
     override fun onBindViewHolder(holder: SimpleListItemView.ViewHolder, position: Int) {
         val data = getItem(position)
-        holder.view.text = data.text
-        holder.itemView.setOnClickListener {
-            onTapListener.invoke(data.original)
+        holder.view.text = data?.text
+        holder.itemView.apply {
+            if (data != null) {
+                setOnClickListener {
+                    onTapListener.invoke(data.original)
+                }
+            } else {
+                setOnClickListener(null)
+            }
         }
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/RepositoriesPagingSource.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/RepositoriesPagingSource.kt
@@ -1,0 +1,63 @@
+package jp.co.yumemi.android.code_check.pages.search
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import io.github.tshion.android.codecheck.core.SearchUseCase
+import jp.co.yumemi.android.code_check.organisms.repository_list_view.RepositoryListItemViewData
+
+/**
+ * ページング出来るリポジトリ一覧情報
+ */
+class RepositoriesPagingSource private constructor(
+    private val keyword: String,
+    private val searchUseCase: SearchUseCase,
+) : PagingSource<Int, RepositoryListItemViewData>() {
+
+    override fun getRefreshKey(
+        state: PagingState<Int, RepositoryListItemViewData>,
+    ) = state.anchorPosition?.let {
+        val anchorPage = state.closestPageToPosition(it)
+        return@let anchorPage?.prevKey?.plus(1)
+            ?: anchorPage?.nextKey?.minus(1)
+    }
+
+    override suspend fun load(
+        params: LoadParams<Int>,
+    ) = try {
+        val currentPage = params.key ?: 1
+
+        val result = searchUseCase.searchRepositories(keyword, currentPage)
+
+        // TODO: View 都合による変換ロジックの移動
+        val data = result.items.map { RepositoryListItemViewData(it) }
+
+        LoadResult.Page(
+            data = data,
+            prevKey = null,
+            nextKey = (currentPage + 1).takeIf { result.hasMore },
+        )
+    } catch (e: Exception) {
+        LoadResult.Error(e)
+    }
+
+
+    companion object {
+
+        /**
+         * ページャーの作成
+         *
+         * @param keyword 検索キーワード
+         * @param searchUseCase 検索フロー
+         */
+        fun newPager(
+            keyword: String,
+            searchUseCase: SearchUseCase,
+        ) = PagingConfig(
+            pageSize = 50, // FIXME: RepositoryQueryEntity の値を利用する
+        ).let {
+            Pager(it) { RepositoriesPagingSource(keyword, searchUseCase) }
+        }
+    }
+}

--- a/app_core/src/main/java/io/github/tshion/android/codecheck/core/entities/RepositoryQueryEntity.kt
+++ b/app_core/src/main/java/io/github/tshion/android/codecheck/core/entities/RepositoryQueryEntity.kt
@@ -18,8 +18,15 @@ public class RepositoryQueryEntity internal constructor(
 
     /** 1ページあたりの結果 */
     @IntRange(from = 1, to = 100)
-    public val perPage: Int = 50
+    public val perPage: Int = PER_PAGE
 
     /** 並び替えのルール */
     public val sort: String? = null
+
+
+    public companion object {
+
+        /** 1ページ当たりに読み込む件数 */
+        public const val PER_PAGE: Int = 50
+    }
 }

--- a/variables.gradle
+++ b/variables.gradle
@@ -40,6 +40,7 @@ ext {
                             fragment: "androidx.navigation:navigation-fragment-ktx:${versionNavigation}",
                             ui      : "androidx.navigation:navigation-ui-ktx:${versionNavigation}",
                     ],
+                    paging          : 'androidx.paging:paging-runtime:3.1.1',
                     recyclerview    : 'androidx.recyclerview:recyclerview:1.2.1',
                     uiautomator     : 'androidx.test.uiautomator:uiautomator:2.2.0',
             ],


### PR DESCRIPTION
* [x] 既存改良

## 概要
検索画面の結果一覧をスクロールすると、追加で表示データを読み込めるようにしました。



## 変更点
### 追加
* リポジトリの検索結果を取り扱うページング実装の追加

### 修正
* ページングできるかどうかの判定修正
    * `incomplete_results` の意味合いが違ったので修正
* 検索結果の結果一覧データ読み込みの修正



## 確認事項
* [ ] 検索画面の結果一覧をスクロールすると、適宜通信が実行され、スクロールし続けることが出来る



## 備考
* GitHub REST API は単位時間あたりで通信制限があり、それに引っ掛かりやすくなるので、実運用に適しているかは別途検討が必要です
