### PR TITLE
#119 アプリ起動フローの整備

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/launcher/LauncherFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/launcher/LauncherFragment.kt
@@ -2,11 +2,15 @@ package jp.co.yumemi.android.code_check.pages.launcher
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import jp.co.yumemi.android.code_check.atoms.LoadingOverlay
+import kotlinx.coroutines.launch
 
 /**
  * アプリ起動画面
@@ -19,5 +23,14 @@ class LauncherFragment : Fragment() {
         savedInstanceState: Bundle?
     ) = LoadingOverlay(inflater.context).apply {
         layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val action = LauncherFragmentDirections.navGoSearch()
+            findNavController().navigate(action)
+        }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/launcher/LauncherFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/launcher/LauncherFragment.kt
@@ -1,0 +1,23 @@
+package jp.co.yumemi.android.code_check.pages.launcher
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.fragment.app.Fragment
+import jp.co.yumemi.android.code_check.atoms.LoadingOverlay
+
+/**
+ * アプリ起動画面
+ */
+class LauncherFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = LoadingOverlay(inflater.context).apply {
+        layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
@@ -42,7 +42,12 @@ class SearchFragment : Fragment(R.layout.page_search) {
         binding = PageSearchBinding.bind(view)
 
         // region 表示設定
-        binding?.pageSearchHeader?.setupWith(findNavController())
+        binding?.pageSearchHeader?.apply {
+            setupWith(findNavController())
+
+            // Note: この画面では遷移元に戻ることが出来ないので無効化
+            navigationIcon = null
+        }
 
         binding?.pageSearchBoxLayout?.setEndIconOnClickListener {
             binding?.apply {

--- a/app/src/main/res/navigation/nav_graph_entry_point.xml
+++ b/app/src/main/res/navigation/nav_graph_entry_point.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_entry_point"
-    app:startDestination="@id/page_search">
+    app:startDestination="@id/page_launcher">
 
     <!-- 結果通知ダイアログの表示 -->
     <action
@@ -48,6 +48,18 @@
         android:name="jp.co.yumemi.android.code_check.pages.detail.DetailFragment"
         android:label="@string/page_detail_title"
         tools:layout="@layout/page_detail" />
+
+    <fragment
+        android:id="@+id/page_launcher"
+        android:name="jp.co.yumemi.android.code_check.pages.launcher.LauncherFragment"
+        android:label="@string/page_launcher_title">
+
+        <action
+            android:id="@+id/nav_go_search"
+            app:destination="@id/page_search"
+            app:popUpTo="@id/nav_graph_entry_point"
+            app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/page_search"

--- a/app/src/main/res/values/page_launcher.xml
+++ b/app/src/main/res/values/page_launcher.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="page_launcher_title">起動画面</string>
+</resources>


### PR DESCRIPTION
* [x] 既存改良

## 概要
アプリ起動後のスプラッシュ -> 起動画面 -> 検索画面というフローを整備しました。



## 変更点
### 追加
* 起動画面の追加

### 修正
* アプリ起動時の画面遷移順を起動画面 -> 検索画面へ変更
    * 検索画面の「戻る」操作を無効化



## 確認事項
* [ ] 起動画面にブレイクポイントを置いてデバッグすると、検索画面の表示前にブレイクされる



## 備考
* 特になし
