### PR TITLE
#146 検索画面で、エラーダイアログが多重表示される問題の修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
@@ -17,6 +17,7 @@ import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.PageSearchBinding
 import jp.co.yumemi.android.code_check.organisms.repository_list_view.RepositoryListViewAdapter
 import jp.co.yumemi.android.code_check.pages.detail.DetailViewData
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
@@ -74,38 +75,40 @@ class SearchFragment : Fragment(R.layout.page_search) {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
+                    viewModel.error.filterNotNull().collect { e ->
+                        when (e) {
+                            is IllegalArgumentException,
+                            is IndexOutOfBoundsException -> NavGraphEntryPointDirections.navShowNotifyDialog(
+                                title = getString(R.string.page_search_error_title_invalid),
+                                message = getString(R.string.page_search_error_message_invalid),
+                            )
+
+                            is IOException -> NavGraphEntryPointDirections.navShowNotifyDialog(
+                                title = getString(R.string.page_search_error_title_http),
+                                message = getString(R.string.page_search_error_message_offline),
+                            )
+
+                            else -> {
+                                Timber.e(e)
+                                NavGraphEntryPointDirections.navShowNotifyDialog(
+                                    title = getString(R.string.page_search_error_title_http),
+                                    message = getString(R.string.page_search_error_message_http),
+                                )
+                            }
+                        }.also { findNavController().navigate(it) }
+                    }
+                }
+
+                launch {
                     viewModel.isLoading.collect {
                         binding?.pageSearchLoading?.isVisible = it
                     }
                 }
 
                 launch {
-                    viewModel.searchResult.collect { result ->
-                        result?.onSuccess {
-                            binding?.pageSearchList?.adapter?.submitList(it)
-                            binding?.pageSearchListEmpty?.isVisible = it.isEmpty()
-                        }?.onFailure { e ->
-                            when (e) {
-                                is IllegalArgumentException,
-                                is IndexOutOfBoundsException -> NavGraphEntryPointDirections.navShowNotifyDialog(
-                                    title = getString(R.string.page_search_error_title_invalid),
-                                    message = getString(R.string.page_search_error_message_invalid),
-                                )
-
-                                is IOException -> NavGraphEntryPointDirections.navShowNotifyDialog(
-                                    title = getString(R.string.page_search_error_title_http),
-                                    message = getString(R.string.page_search_error_message_offline),
-                                )
-
-                                else -> {
-                                    Timber.e(e)
-                                    NavGraphEntryPointDirections.navShowNotifyDialog(
-                                        title = getString(R.string.page_search_error_title_http),
-                                        message = getString(R.string.page_search_error_message_http),
-                                    )
-                                }
-                            }.also { findNavController().navigate(it) }
-                        }
+                    viewModel.repositories.filterNotNull().collect {
+                        binding?.pageSearchList?.adapter?.submitList(it)
+                        binding?.pageSearchListEmpty?.isVisible = it.isEmpty()
                     }
                 }
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchFragment.kt
@@ -95,7 +95,10 @@ class SearchFragment : Fragment(R.layout.page_search) {
                                     message = getString(R.string.page_search_error_message_http),
                                 )
                             }
-                        }.also { findNavController().navigate(it) }
+                        }.also {
+                            findNavController().navigate(it)
+                            viewModel.showedError()
+                        }
                     }
                 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchViewModel.kt
@@ -32,20 +32,14 @@ class SearchViewModel(
     private val _isLoading = MutableStateFlow(false)
 
     /** リポジトリ情報 */
-    val repositories: StateFlow<List<RepositoryListItemViewData>>
-    private val _repositories = MutableStateFlow(emptyList<RepositoryListItemViewData>())
-
-    /** 検索結果 */
-    val searchResult: StateFlow<Result<List<RepositoryListItemViewData>>?>
-    private val _searchResult = MutableStateFlow<Result<List<RepositoryListItemViewData>>?>(null)
+    val repositories: StateFlow<List<RepositoryListItemViewData>?>
+    private val _repositories = MutableStateFlow<List<RepositoryListItemViewData>?>(null)
 
 
     init {
         error = _error
         isLoading = _isLoading
         repositories = _repositories
-
-        searchResult = _searchResult
     }
 
 
@@ -58,17 +52,15 @@ class SearchViewModel(
         viewModelScope.launch {
             _error.value = null
             _isLoading.value = true
-            _searchResult.value = null
+            _repositories.value = null
             try {
                 val mapped = withContext(dispatcherDefault) {
                     val result = searchUseCase.searchRepositories(keyword, 1)
                     result.items.map { RepositoryListItemViewData(it) }
                 }
                 _repositories.value = mapped
-                _searchResult.value = Result.success(mapped)
             } catch (e: Exception) {
                 _error.value = e
-                _searchResult.value = Result.failure(e)
             }
             _isLoading.value = false
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/pages/search/SearchViewModel.kt
@@ -33,7 +33,7 @@ class SearchViewModel(
 
     /** リポジトリ情報 */
     val repositories: StateFlow<List<RepositoryListItemViewData>>
-    private val _repositories = MutableStateFlow<List<RepositoryListItemViewData>>(emptyList())
+    private val _repositories = MutableStateFlow(emptyList<RepositoryListItemViewData>())
 
     /** 検索結果 */
     val searchResult: StateFlow<Result<List<RepositoryListItemViewData>>?>
@@ -72,6 +72,13 @@ class SearchViewModel(
             }
             _isLoading.value = false
         }
+    }
+
+    /**
+     * エラー表示の完了
+     */
+    fun showedError() {
+        _error.value = null
     }
 
 

--- a/variables.gradle
+++ b/variables.gradle
@@ -8,7 +8,7 @@ ext {
     // アプリバージョン
     def appVersionMajor = 1
     def appVersionMinor = 2
-    def appVersionPatch = 1
+    def appVersionPatch = 2
     appVersionCode = 10000 * appVersionMajor + 100 * appVersionMinor + appVersionPatch
     appVersionName = "${appVersionMajor}.${appVersionMinor}.${appVersionPatch}"
 


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#146 の不具合の修正。



## 変更点
### 修正
* データのストリームをリポジトリ一覧とエラーの2つに分解
* ストリームの購読処理を調整



## 確認事項
* [ ] #146 > 概要に記載された手順で、ダイアログの多重表示が発生しない
    * ダイアログが出ている状態で画面回転しても、一つしか表示されていない
    * ダイアログを閉じて、画面回転しても、再表示されない
* [ ] minify をかけても、アプリがクラッシュしない
* [ ] アプリのバージョンを確認すると 1.2.2 である



## 備考
* #121 でJetpack Paging ライブラリを使った無限スクロールを計画しているので、その構造と相性が良さそうな形に留めました
    * `SearchViewModel#error` は `PagingDataAdapter#loadStateFlow` を使った実装に置き換わると予想しました
