### PR TITLE
#120 OSS ライセンス表記の整備と、テスト遷移の実装整備

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -67,6 +67,7 @@ Git 管理から外しているため、試す際は追加でセットアップ�
     * [Material Design](https://github.com/material-components/material-components-android) ([Maven Google](https://mvnrepository.com/artifact/com.google.android.material/material))
     * OkHttp BOM ([Maven Central](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom))
         * [OkHttp](https://github.com/square/okhttp)
+    * [Play Services OSS Licenses](https://developers.google.com/android/guides/opensource) ([Maven Google](https://mvnrepository.com/artifact/com.google.android.gms/play-services-oss-licenses))
     * [Timber](https://github.com/JakeWharton/timber) ([Maven Central](https://mvnrepository.com/artifact/com.jakewharton.timber/timber))
 * 開発設定
     * [AutoService](https://github.com/google/auto/tree/main/service) ([Maven Central](https://mvnrepository.com/artifact/com.google.auto.service/auto-service))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,9 @@ plugins {
     // Firebase Crashlytics Gradle
     alias(libs.plugins.firebase.crashlytics)
 
-    // Google GMS Google Services Gradle Plugin
+    // Google GMS
     alias(libs.plugins.gms.googleServices) apply false
+    alias(libs.plugins.gms.ossLicenses)
 }
 
 
@@ -109,6 +110,9 @@ dependencies {
     // Firebase
     releaseImplementation(platform(libs.firebase.bom))
     releaseImplementation(libs.firebase.crashlytics)
+
+    // GMS
+    implementation(libs.gms.ossLicenses)
 
     // Hyperion
     debugImplementation(libs.hyperion.attr)

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/DemoHyperionPlugin.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/DemoHyperionPlugin.kt
@@ -49,6 +49,10 @@ class DemoHyperionPlugin : Plugin() {
             createNavigator(R.string.hyperion_show_demo_title_show_dialog) {
                 showDialogDemoSpecs
             },
+            createDemo(R.string.hyperion_show_demo_title_launch_license) {
+                val direction = NavGraphDemoEntryPointDirections.navLaunchLicense()
+                it.get()?.navigate(direction)
+            },
             createDemo(
                 R.string.hyperion_show_demo_title_launch_app_settings,
                 subtitle = "OS の設定アプリを起動する",

--- a/app/src/debug/res/navigation/nav_graph_demo_entry_point.xml
+++ b/app/src/debug/res/navigation/nav_graph_demo_entry_point.xml
@@ -5,16 +5,26 @@
     android:id="@+id/nav_graph_demo_entry_point"
     app:startDestination="@id/page_demo">
 
+    <!-- ライセンス表記の起動 -->
+    <action
+        android:id="@+id/nav_launch_license"
+        app:destination="@id/activity_license" />
+
     <!-- 結果通知ダイアログの表示 -->
     <action
         android:id="@+id/nav_show_notify_dialog"
-        app:destination="@id/template_notify_dialog"
-        app:popUpToInclusive="true"/>
+        app:destination="@id/template_notify_dialog" />
 
     <!-- リトライダイアログの表示 -->
     <action
         android:id="@+id/nav_show_retry_dialog"
         app:destination="@id/template_retry_dialog" />
+
+
+    <!-- ライセンス表記 -->
+    <activity
+        android:id="@+id/activity_license"
+        android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity" />
 
 
     <dialog

--- a/app/src/debug/res/values/hyperion.xml
+++ b/app/src/debug/res/values/hyperion.xml
@@ -6,6 +6,7 @@
     <!-- 操作デモのタイトル -->
     <string name="hyperion_show_demo_title_launch_app_settings">アプリ設定の起動</string>
     <string name="hyperion_show_demo_title_launch_dev_settings">開発者設定の起動</string>
+    <string name="hyperion_show_demo_title_launch_license">ライセンス表記の起動</string>
     <string name="hyperion_show_demo_title_show_dialog">ダイアログ表示</string>
     <string name="hyperion_show_demo_title_show_notify_dialog">結果通知ダイアログの表示</string>
     <string name="hyperion_show_demo_title_show_retry_dialog">リトライダイアログの表示</string>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- ライセンス表記: 詳細 -->
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/Theme.App.License"
+            android:exported="false" />
+
+        <!-- ライセンス表記: 一覧 -->
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/Theme.App.License"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/res/navigation/nav_graph_entry_point.xml
+++ b/app/src/main/res/navigation/nav_graph_entry_point.xml
@@ -5,6 +5,11 @@
     android:id="@+id/nav_graph_entry_point"
     app:startDestination="@id/page_search">
 
+    <!-- ライセンス表記の起動 -->
+    <action
+        android:id="@+id/nav_launch_license"
+        app:destination="@id/activity_license" />
+
     <!-- 結果通知ダイアログの表示 -->
     <action
         android:id="@+id/nav_show_notify_dialog"
@@ -14,6 +19,12 @@
     <action
         android:id="@+id/nav_show_retry_dialog"
         app:destination="@id/template_retry_dialog" />
+
+
+    <!-- ライセンス表記 -->
+    <activity
+        android:id="@+id/activity_license"
+        android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity" />
 
 
     <dialog

--- a/app/src/main/res/values/app.xml
+++ b/app/src/main/res/values/app.xml
@@ -22,6 +22,12 @@
         <item name="colorPrimary">@color/app_accent</item>
     </style>
 
+    <!-- ライセンス表記のテーマ -->
+    <style name="Theme.App.License" parent="Theme.App">
+        <item name="windowActionBar">true</item>
+        <item name="windowNoTitle">false</item>
+    </style>
+
 
     <!-- 配色ルール関連 -->
     <color name="app_main">#24292F</color>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,9 @@ desugar = "com.android.tools:desugar_jdk_libs:2.0.4"
 firebase-bom = "com.google.firebase:firebase-bom:32.6.0"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 
+# GMS
+gms-ossLicenses = "com.google.android.gms:play-services-oss-licenses:17.0.1"
+
 # Hyperion
 hyperion-attr = { group = "com.willowtreeapps.hyperion", name = "hyperion-attr", version.ref = "hyperion" }
 hyperion-core = { group = "com.willowtreeapps.hyperion", name = "hyperion-core", version.ref = "hyperion" }
@@ -90,6 +93,7 @@ firebase-crashlytics = "com.google.firebase.crashlytics:2.9.9"
 
 # GMS
 gms-googleServices = "com.google.gms.google-services:4.4.0"
+gms-ossLicenses = "com.google.android.gms.oss-licenses-plugin:0.10.6"
 
 # Kotlin
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,14 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    resolutionStrategy {
+        eachPlugin {
+            // 参考文献: https://github.com/google/play-services-plugins/issues/223#issuecomment-1236159132
+            if (requested.id.id == "com.google.android.gms.oss-licenses-plugin") {
+                useModule("com.google.android.gms:oss-licenses-plugin:${requested.version}")
+            }
+        }
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
* [x] 新規追加

## 概要
アプリにGoogle Play Services のOSS ライセンス表記機能を組み込みました。
どこから画面遷移させるかは未定のため、Hyperion プラグインから確認できるようにしました。



## 変更点
### 追加
* OSS ライセンス表記関連の実装
* OSS ライセンス表記の画面遷移周りの実装

### 修正
* 操作デモにOSS ライセンス表記への遷移追加



## 確認事項
* [ ] Hyperion メニューの操作デモから、OSS ライセンス表記の画面へ遷移できる
    * debug ビルドの場合、表示内容が少なくなるのでご注意ください



## 備考
### 参考文献
* [オープンソースの通知を含める  |  Google Play services  |  Google for Developers](https://developers.google.com/android/guides/opensource)
* https://github.com/google/play-services-plugins/issues/223#issuecomment-1236159132
    * Gradle でPlugin が見つからなかったときに参考にした解決方法
