### PR TITLE
#159 アプリバージョンを更新するGradle タスクの整備

### DIFF
--- a/.github/workflows/update-app-version-gradle.yml
+++ b/.github/workflows/update-app-version-gradle.yml
@@ -41,8 +41,7 @@ jobs:
         id: app-version
         run: |
           ./gradlew setVersion -Pargs="${{ inputs.versionMajor }} ${{ inputs.versionMinor }} ${{ inputs.versionPatch }}"
-          echo "$(./gradlew app:showVersionName)" > TMP_LOG
-          echo "$(head -n 1 TMP_LOG)" > TMP_LOG
+          echo "$(./gradlew -q pickVersionName)" > TMP_LOG
           echo "branch-name=feature/update_$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
           echo "message=アプリバージョン更新: $(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update-app-version-gradle.yml
+++ b/.github/workflows/update-app-version-gradle.yml
@@ -1,0 +1,64 @@
+name: Update app version by Gradle
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionMajor:
+        description: 'バージョン情報: major'
+        required: true
+        type: string
+      versionMinor:
+        description: 'バージョン情報: minor'
+        required: true
+        type: string
+      versionPatch:
+        description: 'バージョン情報: patch'
+        required: true
+        type: string
+
+jobs:
+  update-app-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-java
+      - name: set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version-file: '.java-version'
+          distribution: 'microsoft'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Update app version
+        id: app-version
+        run: |
+          ./gradlew setVersion -Pargs="${{ inputs.versionMajor }} ${{ inputs.versionMinor }} ${{ inputs.versionPatch }}"
+          echo "$(./gradlew app:showVersionName)" > TMP_LOG
+          echo "$(head -n 1 TMP_LOG)" > TMP_LOG
+          echo "branch-name=feature/update_$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+          echo "message=アプリバージョン更新: $(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup git settings
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
+
+      - name: Git push
+        run: |
+          git switch -c ${{ steps.app-version.outputs.branch-name }}
+          git add build.properties
+          git commit -m "${{ steps.app-version.outputs.message }}"
+          git push --set-upstream origin ${{ steps.app-version.outputs.branch-name }}
+
+      - name: Create pull request
+        run: gh pr create --title "${{ steps.app-version.outputs.message }}" --body ""
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "アプリバージョン更新",
+            "label": "Gradle: アプリバージョン更新",
             "type": "process",
             "command": "./gradlew",
             "args": [

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,16 +47,14 @@ android {
     }
     signingConfigs {
         val file = rootProject.file("release.jks")
-        if (file.exists()) {
-            create("release") {
-                storeFile = file
-                storePassword = System.getenv("KEYSTORE_PASSWORD")
-                    ?: keystoreProperties.getProperty("KEYSTORE_PASSWORD", "")
-                keyAlias = System.getenv("KEY_ALIAS")
-                    ?: keystoreProperties.getProperty("KEY_ALIAS", "")
-                keyPassword = System.getenv("KEY_PASSWORD")
-                    ?: keystoreProperties.getProperty("KEY_PASSWORD", "")
-            }
+        create("release") {
+            storeFile = file
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+                ?: keystoreProperties.getProperty("KEYSTORE_PASSWORD", "")
+            keyAlias = System.getenv("KEY_ALIAS")
+                ?: keystoreProperties.getProperty("KEY_ALIAS", "")
+            keyPassword = System.getenv("KEY_PASSWORD")
+                ?: keystoreProperties.getProperty("KEY_PASSWORD", "")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,22 @@ ext {
 }
 
 /**
+ * アプリバージョン文字列の抽出
+ */
+tasks.register("pickVersionName") {
+    doLast {
+        // ファイル読み込み
+        val text = project.rootProject.file("build.properties").readText()
+
+        // アプリバージョン文字列の抽出
+        val match = Regex("""version_name=(\d[\d\.]{0,}\d)""").find(text)
+
+        // 終了表示
+        println(match?.groupValues?.get(1) ?: "unknown")
+    }
+}
+
+/**
  * アプリバージョンの設定
  */
 tasks.register("setVersion") {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Android Studio で開くことで開発作業をする環境が整います。
 ## リリース作業の流れ
 1. リリース対象Pull Request が`develop` ブランチに全てマージされていることを確認する
 1. `develop` ブランチに切り替え、アプリバージョンを更新し、コミットする
-    * [variables.gradle](../build.gradle.kts) 内を確認してください
+    * VSCode 「Gradle: アプリバージョンの更新」で更新することもできる
 1. `develop` ブランチから`released` ブランチにPull Request を作成する
     * 例: [PR #16](https://github.com/tshion/yumemi-inc_android-engineer-codecheck/pull/16)
 1. 問題なければPull Request をマージする


### PR DESCRIPTION
* [x] 既存改良

## 概要
元々アプリバージョンをGradle のext で管理していましたが、
本PR では別ファイルに切り出して、Gradle タスクで更新できるようにしました。



## 変更点
### 追加
* Gradle タスクの追加
    * アプリバージョン情報の更新
    * アプリバージョン情報を抜き出し
* アプリバージョン更新Pull Request を生成するGitHub Actions の追加

### 修正
* アプリバージョン情報の記述場所の変更
    * Gradle の `ext` から別ファイルbuild.properties に変更しました
    * ファイル内容の書き換えを行なっているので、別ファイルに切り出して、意図しない変更を防ぐようにしました
* 本リポジトリを `git clone` した直後にGradle タスクを実行すると、エラーになる不具合の修正
    * 理由は後述する「備考」に記載します
* リリース作業のドキュメント調整



## 確認事項
* [ ] プロジェクトルートで `./gradlew -q pickVersionName` を実行するとbuild.properties の version_name の値が表示される
* [ ] プロジェクトルートで `./gradlew -q setVersion -Pargs="x y z"` を実行するとbuild.properties の値が書き換わる
    * `x`, `y`, `z` に正整数を指定してください
* [ ] VSCode タスク `アプリバージョン更新` を実行するとbuild.properties の値が書き換わる


※GitHub Actions は下記の制約があるので、ある程度動作確認が取れたらマージしてから試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.

※リポジトリ設定の Actions > General >Workflow permissions で Allow GitHub Actions to create and approve pull requests を有効にしてください。



## 備考
### 技術選定メモ
* iOS 版と揃えるのであれば、Ruby も候補になるが、改めて環境構築する必要があるので不採用
    * https://github.com/tshion/yumemi-inc_ios-engineer-codecheck/pull/4
* Gradle はビルドする際などで既に利用されており、何もしなくても使える可能性が高いので採用

### Gradle タスクの件
本リポジトリを `git clone` し、VSCode タスク `Gradle: アプリバージョン更新` を実行すると、
下記のログを出力し、失敗してしまう。
release.jks の取り扱いが原因なので、本PR で調整しました。

``` log
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* Where:
Build file '???/yumemi-inc_android-engineer-codecheck/app/build.gradle.kts' line: 74

* What went wrong:
SigningConfig with name 'release' not found.
```
