### PR TITLE
#159 アプリバージョンを更新するJShell の追加

### DIFF
--- a/.github/workflows/update-app-version-jshell.yml
+++ b/.github/workflows/update-app-version-jshell.yml
@@ -1,0 +1,60 @@
+name: Update app version by JShell
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionMajor:
+        description: 'バージョン情報: major'
+        required: true
+        type: string
+      versionMinor:
+        description: 'バージョン情報: minor'
+        required: true
+        type: string
+      versionPatch:
+        description: 'バージョン情報: patch'
+        required: true
+        type: string
+
+jobs:
+  update-app-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-java
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version-file: '.java-version'
+          distribution: 'microsoft'
+          cache: gradle
+
+      - name: Update app version
+        id: app-version
+        run: |
+          jshell -R-Dargs="${{ inputs.versionMajor }} ${{ inputs.versionMinor }} ${{ inputs.versionPatch }}" scripts/set-version.jsh
+          echo "$(jshell scripts/pick-version-name.jsh)" > TMP_LOG
+          echo "branch-name=feature/update_$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+          echo "message=アプリバージョン更新: $(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup git settings
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
+
+      - name: Git push
+        run: |
+          git switch -c ${{ steps.app-version.outputs.branch-name }}
+          git add Build.xcconfig
+          git commit -m "${{ steps.app-version.outputs.message }}"
+          git push --set-upstream origin ${{ steps.app-version.outputs.branch-name }}
+
+      - name: Create pull request
+        run: gh pr create --title "${{ steps.app-version.outputs.message }}" --body ""
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "アプリバージョン更新",
+            "type": "process",
+            "command": "./gradlew",
+            "args": [
+                "setVersion",
+                "-Pargs=${input:versionMajor} ${input:versionMinor} ${input:versionPatch}",
+            ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "versionMajor",
+            "type": "promptString",
+            "description": "バージョン情報: major"
+        },
+        {
+            "id": "versionMinor",
+            "type": "promptString",
+            "description": "バージョン情報: minor"
+        },
+        {
+            "id": "versionPatch",
+            "type": "promptString",
+            "description": "バージョン情報: patch"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,10 +6,10 @@
         {
             "label": "アプリバージョン更新",
             "type": "process",
-            "command": "./gradlew",
+            "command": "jshell",
             "args": [
-                "setVersion",
-                "-Pargs=${input:versionMajor} ${input:versionMinor} ${input:versionPatch}",
+                "-R-Dargs=${input:versionMajor} ${input:versionMinor} ${input:versionPatch}",
+                "scripts/set-version.jsh",
             ]
         }
     ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "アプリバージョン更新",
+            "label": "JShell: アプリバージョン更新",
             "type": "process",
             "command": "jshell",
             "args": [

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,10 @@ plugins {
 }
 
 
+// アプリビルド情報の読み取り
+val buildProperties = Properties()
+buildProperties.load(FileInputStream(rootProject.file("build.properties")))
+
 // keystore.properties の読み取り
 val keystoreProperties = Properties()
 try {
@@ -36,8 +40,8 @@ android {
         applicationId = "jp.co.yumemi.android.codecheck"
         minSdk = rootProject.extra["androidApiMin"] as Int
         targetSdk = rootProject.extra["androidApiTarget"] as Int
-        versionCode = rootProject.extra["appVersionCode"] as Int
-        versionName = rootProject.extra["appVersionName"].toString()
+        versionCode = "${buildProperties["version_code"]}".toIntOrNull()
+        versionName = "${buildProperties["version_name"]}"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,6 @@ ext {
     // アプリ構成
     extra["androidApiMin"] = 23
     extra["androidApiTarget"] = 34
-
-    // アプリバージョン
-    extra["appVersionCode"] = 10202
-    extra["appVersionName"] = "1.2.2"
 }
 
 /**
@@ -41,16 +37,10 @@ tasks.register("setVersion") {
 
 
         // ファイル出力
-        val file = project.rootProject.file("build.gradle.kts")
+        val file = project.rootProject.file("build.properties")
         file.readText()
-            .replace(
-                Regex("""(extra\["appVersionCode"\] = )\d+"""),
-                "$1$versionCode",
-            )
-            .replace(
-                Regex("""(extra\["appVersionName"\] = ")\d[\d\.]{0,}\d(")"""),
-                "$1$versionName$2",
-            )
+            .replace(Regex("""(version_code=)\d+"""), "$1$versionCode")
+            .replace(Regex("""(version_name=)\d[\d\.]{0,}\d"""), "$1$versionName")
             .also { file.writeText(it) }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,58 @@ ext {
     extra["androidApiTarget"] = 34
 
     // アプリバージョン
-    val appVersionMajor = 1
-    val appVersionMinor = 2
-    val appVersionPatch = 2
-    extra["appVersionCode"] = 10000 * appVersionMajor + 100 * appVersionMinor + appVersionPatch
-    extra["appVersionName"] = "${appVersionMajor}.${appVersionMinor}.${appVersionPatch}"
+    extra["appVersionCode"] = 10202
+    extra["appVersionName"] = "1.2.2"
+}
+
+/**
+ * アプリバージョンの設定
+ */
+tasks.register("setVersion") {
+    doLast {
+        val args = "${project.properties["args"]}".split(" ")
+        if (args.count() != 3) {
+            throw IllegalArgumentException("引数を３つ指定してください")
+        }
+
+        val major = args[0].toIntOrNull() ?: -1
+        if (major < 0) {
+            throw IllegalArgumentException("major には正整数を指定してください")
+        }
+
+        val minor = args[1].toIntOrNull() ?: -1
+        if (minor !in 0..99) {
+            throw IllegalArgumentException("minor には1 ~ 2桁の正整数を指定してください")
+        }
+
+        val patch = args[2].toIntOrNull() ?: -1
+        if (minor !in 0..99) {
+            throw IllegalArgumentException("patch には1 ~ 2桁の正整数を指定してください")
+        }
+
+
+        // バージョン情報の算出
+        val versionCode = major * 10000 + minor * 100 + patch
+        val versionName = "${major}.${minor}.${patch}"
+
+
+        // ファイル出力
+        val file = project.rootProject.file("build.gradle.kts")
+        file.readText()
+            .replace(
+                Regex("""(extra\["appVersionCode"\] = )\d+"""),
+                "$1$versionCode",
+            )
+            .replace(
+                Regex("""(extra\["appVersionName"\] = ")\d[\d\.]{0,}\d(")"""),
+                "$1$versionName$2",
+            )
+            .also { file.writeText(it) }
+
+
+        // 終了表示
+        println("Set code: $versionCode, name: $versionName")
+    }
 }
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,50 +5,6 @@ ext {
     extra["androidApiTarget"] = 34
 }
 
-/**
- * アプリバージョンの設定
- */
-tasks.register("setVersion") {
-    doLast {
-        val args = "${project.properties["args"]}".split(" ")
-        if (args.count() != 3) {
-            throw IllegalArgumentException("引数を３つ指定してください")
-        }
-
-        val major = args[0].toIntOrNull() ?: -1
-        if (major < 0) {
-            throw IllegalArgumentException("major には正整数を指定してください")
-        }
-
-        val minor = args[1].toIntOrNull() ?: -1
-        if (minor !in 0..99) {
-            throw IllegalArgumentException("minor には1 ~ 2桁の正整数を指定してください")
-        }
-
-        val patch = args[2].toIntOrNull() ?: -1
-        if (minor !in 0..99) {
-            throw IllegalArgumentException("patch には1 ~ 2桁の正整数を指定してください")
-        }
-
-
-        // バージョン情報の算出
-        val versionCode = major * 10000 + minor * 100 + patch
-        val versionName = "${major}.${minor}.${patch}"
-
-
-        // ファイル出力
-        val file = project.rootProject.file("build.properties")
-        file.readText()
-            .replace(Regex("""(version_code=)\d+"""), "$1$versionCode")
-            .replace(Regex("""(version_name=)\d[\d\.]{0,}\d"""), "$1$versionName")
-            .also { file.writeText(it) }
-
-
-        // 終了表示
-        println("Set code: $versionCode, name: $versionName")
-    }
-}
-
 plugins {
     // Android Gradle Plugin
     alias(libs.plugins.android.application) apply false

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,3 @@
+# App version info
+version_code=10202
+version_name=1.2.2

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Android Studio で開くことで開発作業をする環境が整います。
 ## リリース作業の流れ
 1. リリース対象Pull Request が`develop` ブランチに全てマージされていることを確認する
 1. `develop` ブランチに切り替え、アプリバージョンを更新し、コミットする
-    * [variables.gradle](../build.gradle.kts) 内を確認してください
+    * VSCode 「JShell: アプリバージョンの更新」で更新することもできる
 1. `develop` ブランチから`released` ブランチにPull Request を作成する
     * 例: [PR #16](https://github.com/tshion/yumemi-inc_android-engineer-codecheck/pull/16)
 1. 問題なければPull Request をマージする

--- a/scripts/pick-version-name.jsh
+++ b/scripts/pick-version-name.jsh
@@ -1,0 +1,29 @@
+// アプリバージョン文字列の抽出
+//
+// 注意事項
+// * ".java-version" に記載されているバージョンで実行してください
+
+
+try {
+    // 作業対象ファイルの設定と検証
+    final var file = new File("build.properties");
+    if (!file.exists() || !file.isFile()) {
+        throw new IllegalArgumentException("%s にファイルが存在しません".formatted(file.getAbsolutePath()));
+    }
+
+    // ファイル読み込み
+    final var text = Files.readString(file.toPath());
+
+    // アプリバージョン文字列の抽出
+    final var matches = Pattern.compile("version_name=(\\d[\\d\\.]{0,}\\d)").matcher(text);
+    matches.find();
+    final var versionName = matches.group(1);
+
+    // 終了表示
+    System.out.println(versionName);
+} catch (Exception e) {
+    System.out.println(e.getMessage());
+}
+
+// jshell のREPL モードの終了
+/exit

--- a/scripts/set-version.jsh
+++ b/scripts/set-version.jsh
@@ -1,0 +1,58 @@
+// アプリバージョンの更新
+//
+// 注意事項
+// * ".java-version" に記載されているバージョンで実行してください
+
+
+try {
+    // 作業対象ファイルの設定と検証
+    final var file = new File("build.properties");
+    if (!file.exists() || !file.isFile()) {
+        throw new IllegalArgumentException("%s にファイルが存在しません".formatted(file.getAbsolutePath()));
+    }
+
+
+    // コマンドライン引数の検証
+    final var args = System.getProperty("args").toString().split(" ");
+    if (args.length != 3) {
+        throw new IllegalArgumentException("引数を３つ指定してください");
+    }
+
+    final var major = Integer.parseInt(args[0]);
+    if (major < 0) {
+        throw new IllegalArgumentException("major には正整数を指定してください");
+    }
+
+    final var minor = Integer.parseInt(args[1]);
+    if (minor < 0 || 99 < minor) {
+        throw new IllegalArgumentException("minor には1 ~ 2桁の正整数を指定してください");
+    }
+
+    final var patch = Integer.parseInt(args[2]);
+    if (patch < 0 || 99 < patch) {
+        throw new IllegalArgumentException("patch には1 ~ 2桁の正整数を指定してください");
+    }
+
+
+    // バージョン情報の算出
+    final var versionCode = major * 10000 + minor * 100 + patch;
+    final var versionName = "%d.%d.%d".formatted(major, minor, patch);
+
+
+    // ファイル出力
+    final var path = file.toPath();
+    final var text = Files.readString(path)
+        .replaceAll("(version_code=)\\d+", "$1%d".formatted(versionCode))
+        .replaceAll("(version_name=)\\d[\\d\\.]{0,}\\d", "$1%s".formatted(versionName))
+        ;
+    Files.writeString(path, text);
+
+
+    // 終了表示
+    System.out.println("Set code: %d, name: %s".formatted(versionCode, versionName));
+} catch (Exception e) {
+    System.out.println(e.getMessage());
+}
+
+// jshell のREPL モードの終了
+/exit


### PR DESCRIPTION
* [x] 既存改良

## 概要
#160 では、アプリバージョン更新をGradle タスクで実現していました。
しかし、Java 9 以上が動く環境であれば JShell を利用する手も考えられるので、再実装してみました。



## 変更点
### 追加
* JShell の追加
    * アプリバージョン情報の更新
    * アプリバージョン情報を抜き出し
* アプリバージョン更新Pull Request を生成するGitHub Actions の追加

### 修正
* リリース作業のドキュメント調整

### 削除
* Gradle タスクの削除



## 確認事項
* [ ] プロジェクトルートで `jshell scripts/pick-version-name.jsh` を実行するとbuild.properties の `version_name` の値が表示される
* [ ] プロジェクトルートで `jshell -R-Dargs="x y z" scripts/set-version.jsh` を実行するとbuild.properties の値が書き換わる
    * `x`, `y`, `z` に正整数を指定してください
* [ ] VSCode タスク `JShell: アプリバージョン更新` を実行するとbuild.properties の値が書き換わる

※GitHub Actions は下記の制約があるので、ある程度動作確認が取れたらマージしてから試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.

※リポジトリ設定の Actions > General >Workflow permissions で Allow GitHub Actions to create and approve pull requests を有効にしてください。


## 備考
### 参考文献
* [Javaスクリプト入門 - きしだのHatena](https://nowokay.hatenablog.com/entry/2019/06/29/035023)
