### PR TITLE
#159 GitHub Actions の調整

### DIFF
--- a/.github/workflows/update-app-version-jshell.yml
+++ b/.github/workflows/update-app-version-jshell.yml
@@ -28,7 +28,7 @@ jobs:
 
       # https://github.com/actions/setup-java
       - name: set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version-file: '.java-version'
           distribution: 'microsoft'
@@ -50,7 +50,7 @@ jobs:
       - name: Git push
         run: |
           git switch -c ${{ steps.app-version.outputs.branch-name }}
-          git add Build.xcconfig
+          git add build.properties
           git commit -m "${{ steps.app-version.outputs.message }}"
           git push --set-upstream origin ${{ steps.app-version.outputs.branch-name }}
 


### PR DESCRIPTION
* [x] 既存改良
* [x] 不具合修正

## 概要
#161 マージ後にGitHub Actions を試しに実行してみたところ、下記が判明したため、対応した。

* `git add` する際のファイル名の誤植
    * https://github.com/tshion/yumemi-inc_android-engineer-codecheck/actions/runs/8127910177
        > Run git switch -c feature/update_2.3.4
Switched to a new branch 'feature/update_2.3.4'
fatal: pathspec 'Build.xcconfig' did not match any files
Error: Process completed with exit code 128.
* setup-java のアップデート
    > update-app-version
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.



## 変更点
### 修正
* 概要に記載した内容の対応



## 確認事項
※GitHub Actions は下記の制約があるので、ある程度動作確認が取れたらマージしてから試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.



## 備考
特になし
