### PR TITLE
#174 GitHub Actions 関連の実装ブラッシュアップ3

### DIFF
--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -17,8 +17,9 @@ concurrency:
 jobs:
   create-release-pr:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'アプリバージョン更新'))
+      github.ref_type == 'branch' &&
+      (github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'アプリバージョン更新')))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -41,7 +42,7 @@ jobs:
         id: notes
         run: |
           echo "$(gh release list --exclude-drafts --exclude-pre-releases --order desc --limit 1 --json tagName --jq '.[].tagName')" > TMP_LOG
-          echo "$(gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/releases/generate-notes -f "tag_name=preview${{ steps.version.outputs.name }}" -f "target_commitish=develop" -f "previous_tag_name=$(cat TMP_LOG)")" > TMP_LOG
+          echo "$(gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/releases/generate-notes -f "tag_name=preview${{ steps.version.outputs.name }}" -f "target_commitish=${{ github.ref_name }}" -f "previous_tag_name=$(cat TMP_LOG)")" > TMP_LOG
           echo "diff=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#175, #177 で漏れていた実装を修正しました。



## 変更点
### 修正
* note を生成する際、参照先のブランチ名が違うことによりエラーが発生する問題を修正



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.