### PR TITLE
#174 GitHub Actions 関連の実装ブラッシュアップ4

### DIFF
--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -22,6 +22,7 @@ jobs:
         (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'アプリバージョン更新')))
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       # https://github.com/actions/checkout


### PR DESCRIPTION
* [x] 不具合修正

## 概要
#175, #177, #181 で漏れていた実装を修正しました。



## 変更点
### 修正
* note を生成する際、不足していた権限を追加
    * https://docs.github.com/ja/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release
        > トークンには次のアクセス許可が設定されている必要があります:
        > 
        > contents:write



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.