### PR TITLE
#174 GitHub Actions 関連の実装ブラッシュアップ5

### DIFF
--- a/.github/READ_ME.md
+++ b/.github/READ_ME.md
@@ -8,6 +8,7 @@ GitHub 用の設定や関連する実装などの置き場。
 [scripts/get-version-name/](./scripts/get-version-name/) | バージョン名の取得
 [scripts/set-version/](./scripts/set-version/) | バージョン情報の設定
 [scripts/can-release.sh](./scripts/can-release.sh) | リリース出来るかどうか
+[scripts/presume-release-notes.bash](./scripts/presume-release-notes.bash) | まだリリースしていないGit タグのリリースノートの推定
 [workflows/140-create-version-pr.yml](./workflows/140-create-version-pr.yml) | バージョン情報を更新するPull Request 作成
 [workflows/160-create-release-pr.yml](./workflows/160-create-release-pr.yml) | リリース候補の変更内容をまとめたPull Request 作成
 [workflows/180-deploy.yml](./workflows/180-deploy.yml) | リリース(デプロイ)

--- a/.github/scripts/can-release.bash
+++ b/.github/scripts/can-release.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# 引数で指定されたGit タグ名でリリースできるかどうか
+# ※GitHub CLI のアクセス権限等の設定が必要
+#
+# $1 -> Git タグ名
+
 if gh release view $1 > /dev/null; then
   echo "$1 is already released!"
   exit 1

--- a/.github/scripts/presume-release-notes.bash
+++ b/.github/scripts/presume-release-notes.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# まだリリースしていないGit タグのリリースノートの推定
+# ※GitHub CLI のアクセス権限等の設定が必要
+#
+# $1 -> リリースしようとしているGit タグ名
+# $2 -> $1 があるGit ブランチ名
+
+latestTag=$(gh release list \
+    --exclude-drafts \
+    --exclude-pre-releases \
+    --order desc --limit 1 \
+    --json tagName --jq '.[].tagName' \
+)
+
+gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/tshion/yumemi-inc_android-engineer-codecheck/releases/generate-notes \
+    -f "tag_name=preview$1" \
+    -f "target_commitish=$2" \
+    -f "previous_tag_name=$latestTag"

--- a/.github/workflows/140-create-version-pr.yml
+++ b/.github/workflows/140-create-version-pr.yml
@@ -42,7 +42,7 @@ jobs:
           echo "branch-name=feature/update_$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
           echo "message=アプリバージョン更新: $(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
       - uses: ./.github/actions/apply-gh-actions-bot-identity
 
@@ -59,4 +59,4 @@ jobs:
           * [ ] 意図したバージョンが設定されている
           * [ ] ビルド出来る"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -41,14 +41,11 @@ jobs:
 
       - name: Generate diff notes
         id: notes
-        run: |
-          echo "$(gh release list --exclude-drafts --exclude-pre-releases --order desc --limit 1 --json tagName --jq '.[].tagName')" > TMP_LOG
-          echo "$(gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/releases/generate-notes -f "tag_name=preview${{ steps.version.outputs.name }}" -f "target_commitish=${{ github.ref_name }}" -f "previous_tag_name=$(cat TMP_LOG)")" > TMP_LOG
-          echo "diff=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+        run: echo "response=$(bash .github/scripts/presume-release-notes.bash preview${{ steps.version.outputs.name }} ${{ github.ref_name }})" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Create pull request
-        run: gh pr create --base released --title "Merge ${{ steps.version.outputs.name }}" --body "${{ steps.notes.outputs.diff }}"
+        run: gh pr create --base released --title "Merge ${{ steps.version.outputs.name }}" --body "${{ fromJson(steps.notes.outputs.response).body }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -37,15 +37,15 @@ jobs:
           bash .github/scripts/can-release.bash $(cat TMP_LOG)
           echo "name=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Generate diff notes
         id: notes
         run: echo "response=$(bash .github/scripts/presume-release-notes.bash preview${{ steps.version.outputs.name }} ${{ github.ref_name }})" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create pull request
         run: gh pr create --base released --title "Merge ${{ steps.version.outputs.name }}" --body "${{ fromJson(steps.notes.outputs.response).body }}"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/180-deploy.yml
+++ b/.github/workflows/180-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           bash .github/scripts/can-release.bash $(cat TMP_LOG)
           echo "name=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -69,4 +69,4 @@ jobs:
       - name: Create release with assets
         run: gh release create "${{ steps.version.outputs.name }}" 'app/build/outputs/apk/release/app-release.apk' 'app/build/outputs/mapping/release/mapping.txt' --generate-notes --title "${{ steps.version.outputs.name }}"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* [x] 既存改良
* [x] 不具合修正

## 概要
#175, #177, #181, #183 で漏れていた実装を修正しました。



## 変更点
### 修正
* GitHub CLI を利用する際、トークン名を間違えていたので修正
    * https://docs.github.com/ja/enterprise-cloud@latest/actions/using-workflows/using-github-cli-in-workflows
* 生成したリリースノートをPull Request に適用する際、JSON の変換が漏れていた箇所を修正
* リリースノートを生成するコマンドを別ファイル化



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.
